### PR TITLE
OV-503: experimentation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitAuditSnapshot.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitAuditSnapshot.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
+
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.UUID
+
+/** Immutable copy of auditable OfficialVisit fields taken after load. */
+data class OfficialVisitAuditSnapshot(
+  val prisonVisitSlotId: Long,
+  val visitDate: LocalDate,
+  val startTime: LocalTime,
+  val endTime: LocalTime,
+  val dpsLocationId: UUID,
+  val visitTypeCode: String,
+  val prisonCode: String,
+  val prisonerNumber: String,
+  val currentTerm: Boolean,
+  val staffNotes: String?,
+  val prisonerNotes: String?,
+  val visitorConcernNotes: String?,
+  val overrideBanBy: String?,
+  val offenderBookId: Long?,
+  val offenderVisitId: Long?,
+  val visitOrderNumber: Long?,
+  val visitStatusCode: String,
+  val completionCode: String?,
+  val completionNotes: String?,
+  val searchTypeCode: String?,
+) {
+  companion object {
+    fun from(visit: OfficialVisitEntity) = OfficialVisitAuditSnapshot(
+      prisonVisitSlotId = visit.prisonVisitSlot.prisonVisitSlotId,
+      visitDate = visit.visitDate,
+      startTime = visit.startTime,
+      endTime = visit.endTime,
+      dpsLocationId = visit.dpsLocationId,
+      visitTypeCode = visit.visitTypeCode.name,
+      prisonCode = visit.prisonCode,
+      prisonerNumber = visit.prisonerNumber,
+      currentTerm = visit.currentTerm,
+      staffNotes = visit.staffNotes,
+      prisonerNotes = visit.prisonerNotes,
+      visitorConcernNotes = visit.visitorConcernNotes,
+      overrideBanBy = visit.overrideBanBy,
+      offenderBookId = visit.offenderBookId,
+      offenderVisitId = visit.offenderVisitId,
+      visitOrderNumber = visit.visitOrderNumber,
+      visitStatusCode = visit.visitStatusCode.name,
+      completionCode = visit.completionCode?.name,
+      completionNotes = visit.completionNotes,
+      searchTypeCode = visit.searchTypeCode?.name,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitEntity.kt
@@ -86,6 +86,9 @@ open class OfficialVisitEntity(
   @Transient
   var auditSnapshot: OfficialVisitAuditSnapshot? = null
 
+  @Transient
+  var auditChildChanges: Boolean = false
+
   @OneToMany(mappedBy = "officialVisit", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   private val officialVisitors: MutableList<OfficialVisitorEntity> = mutableListOf()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitEntity.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
 
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
@@ -12,6 +13,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.Transient
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.officialvisitsapi.common.requireNot
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
@@ -24,6 +26,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.migrate.MigrateVisitRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync.SyncCreateOfficialVisitRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.OfficialVisitAuditEntityListener
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalDateTime.now
@@ -33,6 +36,8 @@ import java.util.UUID
 @Entity
 @Table(name = "official_visit")
 open class OfficialVisitEntity(
+@EntityListeners(OfficialVisitAuditEntityListener::class)
+class OfficialVisitEntity(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val officialVisitId: Long = 0,
@@ -78,6 +83,9 @@ open class OfficialVisitEntity(
 
   var visitOrderNumber: Long? = null,
 ) {
+  @Transient
+  var auditSnapshot: OfficialVisitAuditSnapshot? = null
+
   @OneToMany(mappedBy = "officialVisit", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   private val officialVisitors: MutableList<OfficialVisitorEntity> = mutableListOf()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitEntity.kt
@@ -34,10 +34,10 @@ import java.time.LocalTime
 import java.util.UUID
 
 @Entity
+@EntityListeners(OfficialVisitAuditEntityListener::class)
 @Table(name = "official_visit")
 open class OfficialVisitEntity(
-@EntityListeners(OfficialVisitAuditEntityListener::class)
-class OfficialVisitEntity(
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val officialVisitId: Long = 0,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitorEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/OfficialVisitorEntity.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
 
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
@@ -15,9 +16,11 @@ import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.RelationshipType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.OfficialVisitorAuditEntityListener
 import java.time.LocalDateTime
 
 @Entity
+@EntityListeners(OfficialVisitorAuditEntityListener::class)
 @Table(name = "official_visitor")
 class OfficialVisitorEntity(
   @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
@@ -19,8 +19,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.PrisonerCon
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonVisitSlotRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCreateEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
@@ -39,7 +37,6 @@ class OfficialVisitCreateService(
   private val officialVisitRepository: OfficialVisitRepository,
   private val prisonerVisitedRepository: PrisonerVisitedRepository,
   private val contactsService: ContactsService,
-  private val auditingService: AuditingService,
   private val metricsService: MetricsService,
 ) {
   companion object {
@@ -93,20 +90,6 @@ class OfficialVisitCreateService(
             numberOfVisitors = it.visitorAndContactIds.size.toLong(),
             startTime = request.startTime,
           ),
-        )
-      }.also {
-        auditingService.recordAuditEvent(
-          auditVisitCreateEvent {
-            officialVisitId(it.officialVisitId)
-            summaryText("Official visit created")
-            eventSource("DPS")
-            user(user)
-            prisonCode(prisonCode)
-            prisonerNumber(it.prisonerNumber)
-            detailsText(
-              "Official visit created for prisoner number ${it.prisonerNumber} with ${it.visitorAndContactIds.size} visitor(s)",
-            )
-          },
         )
       }.also {
         it.visitorAndContactIds.forEach { value ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitUpdateService.kt
@@ -55,23 +55,6 @@ class OfficialVisitUpdateService(
     val newPrisonVisitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId!!)
       .orElseThrow { throw ValidationException("Prison visit slot with id ${request.prisonVisitSlotId} not found.") }
 
-    val auditChangeEvent = auditVisitChangeEvent {
-      officialVisitId(ove.officialVisitId)
-      summaryText("Update visit visit type and visit slot")
-      eventSource("DPS")
-      user(user)
-      prisonCode(ove.prisonCode)
-      prisonerNumber(ove.prisonerNumber)
-      changes {
-        change("Visit date", ove.visitDate, request.visitDate)
-        change("Start time", ove.startTime, request.startTime)
-        change("End time", ove.endTime, request.endTime)
-        change("Location", ove.dpsLocationId, request.dpsLocationId)
-        change("Visit type", ove.visitTypeCode, request.visitTypeCode)
-        change("Visit slot", ove.prisonVisitSlot.prisonVisitSlotId, newPrisonVisitSlot.prisonVisitSlotId)
-      }
-    }
-
     val changedOVEntity = ove.apply {
       prisonVisitSlot = newPrisonVisitSlot
       visitDate = request.visitDate!!
@@ -97,8 +80,6 @@ class OfficialVisitUpdateService(
       )
     }
 
-    auditingService.recordAuditEvent(auditChangeEvent)
-
     return OfficialVisitUpdateSlotResponse(
       officialVisitId = updatedVisit.officialVisitId,
       prisonerNumber = updatedVisit.prisonerNumber,
@@ -117,19 +98,6 @@ class OfficialVisitUpdateService(
   ): OfficialVisitUpdateCommentsResponse {
     val ove = officialVisitRepository.findByOfficialVisitIdAndPrisonCode(officialVisitId, prisonCode)
       ?: throw EntityNotFoundException("Official visit with id $officialVisitId and prison code $prisonCode not found")
-
-    val auditChangeEvent = auditVisitChangeEvent {
-      officialVisitId(ove.officialVisitId)
-      summaryText("Update visit comments")
-      eventSource("DPS")
-      user(user)
-      prisonCode(ove.prisonCode)
-      prisonerNumber(ove.prisonerNumber)
-      changes {
-        change("Prisoner notes", ove.prisonerNotes, request.prisonerNotes)
-        change("Staff notes", ove.staffNotes, request.staffNotes)
-      }
-    }
 
     val updatedVisit = officialVisitRepository.saveAndFlush(
       ove.apply {
@@ -151,8 +119,6 @@ class OfficialVisitUpdateService(
         ),
       )
     }
-
-    auditingService.recordAuditEvent(auditChangeEvent)
 
     return OfficialVisitUpdateCommentsResponse(
       officialVisitId = updatedVisit.officialVisitId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingService.kt
@@ -12,7 +12,8 @@ import kotlin.properties.Delegates
 @Service
 class AuditingService(private val auditedEventRepository: AuditedEventRepository) {
   fun recordAuditEvent(auditEvent: AuditEventDto) {
-    auditedEventRepository.saveAndFlush(
+    // Use save() rather than saveAndFlush() so that we do not trigger a recursive Hibernate flush.
+    auditedEventRepository.save(
       AuditedEventEntity(
         officialVisitId = auditEvent.officialVisitId,
         prisonCode = auditEvent.prisonCode,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitAuditEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitAuditEntityListener.kt
@@ -11,6 +11,7 @@ import org.springframework.web.context.request.ServletRequestAttributes
 import uk.gov.justice.digital.hmpps.officialvisitsapi.config.LocalRequestContext
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitAuditSnapshot
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitorEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.ServiceUser
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
@@ -19,6 +20,7 @@ class OfficialVisitAuditEntityListener {
   @PostLoad
   fun onLoad(visit: OfficialVisitEntity) {
     visit.auditSnapshot = OfficialVisitAuditSnapshot.from(visit)
+    visit.auditChildChanges = true
   }
 
   @PostPersist
@@ -39,8 +41,21 @@ class OfficialVisitAuditEntityListener {
   }
 }
 
+class OfficialVisitorAuditEntityListener {
+  @PostPersist
+  fun onCreate(visitor: OfficialVisitorEntity) {
+    if (!visitor.officialVisit.auditChildChanges) return
+
+    OfficialVisitorAuditDelegateHolder.delegate.recordCreated(visitor)
+  }
+}
+
 private object OfficialVisitAuditDelegateHolder {
   lateinit var delegate: OfficialVisitAuditDelegate
+}
+
+private object OfficialVisitorAuditDelegateHolder {
+  lateinit var delegate: OfficialVisitorAuditDelegate
 }
 
 @Component
@@ -52,10 +67,38 @@ class OfficialVisitAuditDelegateRegistrar(private val delegate: OfficialVisitAud
 }
 
 @Component
+class OfficialVisitorAuditDelegateRegistrar(private val delegate: OfficialVisitorAuditDelegate) {
+  @PostConstruct
+  fun register() {
+    OfficialVisitorAuditDelegateHolder.delegate = delegate
+  }
+}
+
+abstract class OfficialVisitAuditSupport(private val userService: UserService) {
+  protected fun eventSource(): String = currentRequestAttributes()
+    ?.request
+    ?.requestURI
+    ?.let { if (it.startsWith("/sync/")) "NOMIS" else "DPS" }
+    ?: "DPS"
+
+  protected fun actorFor(username: String?): User = requestUser()
+    ?: username?.let { userService.getUser(it) ?: ServiceUser(it, it) }
+    ?: ServiceUser("SYSTEM", "SYSTEM")
+
+  private fun requestUser(): User? = (
+    currentRequestAttributes()
+      ?.request
+      ?.getAttribute(LocalRequestContext::class.simpleName) as? LocalRequestContext
+    )?.user
+
+  private fun currentRequestAttributes(): ServletRequestAttributes? = RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes
+}
+
+@Component
 class OfficialVisitAuditDelegate(
   private val auditingService: AuditingService,
-  private val userService: UserService,
-) {
+  userService: UserService,
+) : OfficialVisitAuditSupport(userService) {
   fun recordCreated(visit: OfficialVisitEntity) {
     val actor = actorFor(visit.createdBy)
     auditingService.recordAuditEvent(
@@ -126,22 +169,39 @@ class OfficialVisitAuditDelegate(
       },
     )
   }
+}
 
-  private fun eventSource(): String = currentRequestAttributes()
-    ?.request
-    ?.requestURI
-    ?.let { if (it.startsWith("/sync/")) "NOMIS" else "DPS" }
-    ?: "DPS"
+@Component
+class OfficialVisitorAuditDelegate(
+  private val auditingService: AuditingService,
+  userService: UserService,
+) : OfficialVisitAuditSupport(userService) {
+  fun recordCreated(visitor: OfficialVisitorEntity) {
+    val visit = visitor.officialVisit
+    val relationshipType = visitor.relationshipType()
 
-  private fun actorFor(username: String?): User = requestUser()
-    ?: username?.let { userService.getUser(it) ?: ServiceUser(it, it) }
-    ?: ServiceUser("SYSTEM", "SYSTEM")
+    auditingService.recordAuditEvent(
+      auditVisitCreateEvent {
+        officialVisitId(visit.officialVisitId)
+        summaryText("$relationshipType visitor added")
+        eventSource(eventSource())
+        user(actorFor(visitor.createdBy))
+        prisonCode(visit.prisonCode)
+        prisonerNumber(visit.prisonerNumber)
+        detailsText("$relationshipType visitor ${visitor.name()} added to visit for prisoner number ${visit.prisonerNumber}")
+      },
+    )
+  }
 
-  private fun requestUser(): User? = (
-    currentRequestAttributes()
-      ?.request
-      ?.getAttribute(LocalRequestContext::class.simpleName) as? LocalRequestContext
-    )?.user
+  private fun OfficialVisitorEntity.relationshipType(): String = relationshipTypeCode
+    ?.name
+    ?.lowercase()
+    ?.replaceFirstChar { it.uppercase() }
+    ?: "Unknown"
 
-  private fun currentRequestAttributes(): ServletRequestAttributes? = RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes
+  private fun OfficialVisitorEntity.name(): String = listOfNotNull(firstName?.formatNamePart(), lastName?.formatNamePart())
+    .joinToString(" ")
+    .ifBlank { "Unknown visitor" }
+
+  private fun String.formatNamePart(): String = lowercase().replaceFirstChar { it.uppercase() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitAuditEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitAuditEntityListener.kt
@@ -1,0 +1,147 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing
+
+import jakarta.annotation.PostConstruct
+import jakarta.persistence.PostLoad
+import jakarta.persistence.PostPersist
+import jakarta.persistence.PostUpdate
+import jakarta.persistence.PreRemove
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import uk.gov.justice.digital.hmpps.officialvisitsapi.config.LocalRequestContext
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitAuditSnapshot
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.ServiceUser
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
+
+class OfficialVisitAuditEntityListener {
+  @PostLoad
+  fun onLoad(visit: OfficialVisitEntity) {
+    visit.auditSnapshot = OfficialVisitAuditSnapshot.from(visit)
+  }
+
+  @PostPersist
+  fun onCreate(visit: OfficialVisitEntity) {
+    OfficialVisitAuditDelegateHolder.delegate.recordCreated(visit)
+    visit.auditSnapshot = OfficialVisitAuditSnapshot.from(visit)
+  }
+
+  @PostUpdate
+  fun onUpdate(visit: OfficialVisitEntity) {
+    OfficialVisitAuditDelegateHolder.delegate.recordUpdated(visit, visit.auditSnapshot)
+    visit.auditSnapshot = OfficialVisitAuditSnapshot.from(visit)
+  }
+
+  @PreRemove
+  fun onDelete(visit: OfficialVisitEntity) {
+    OfficialVisitAuditDelegateHolder.delegate.recordDeleted(visit, visit.auditSnapshot)
+  }
+}
+
+private object OfficialVisitAuditDelegateHolder {
+  lateinit var delegate: OfficialVisitAuditDelegate
+}
+
+@Component
+class OfficialVisitAuditDelegateRegistrar(private val delegate: OfficialVisitAuditDelegate) {
+  @PostConstruct
+  fun register() {
+    OfficialVisitAuditDelegateHolder.delegate = delegate
+  }
+}
+
+@Component
+class OfficialVisitAuditDelegate(
+  private val auditingService: AuditingService,
+  private val userService: UserService,
+) {
+  fun recordCreated(visit: OfficialVisitEntity) {
+    val actor = actorFor(visit.createdBy)
+    auditingService.recordAuditEvent(
+      auditVisitCreateEvent {
+        officialVisitId(visit.officialVisitId)
+        summaryText("Official visit created")
+        eventSource(eventSource())
+        user(actor)
+        prisonCode(visit.prisonCode)
+        prisonerNumber(visit.prisonerNumber)
+        detailsText("Official visit created for prisoner number ${visit.prisonerNumber} with ${visit.officialVisitors().size} visitor(s)")
+      },
+    )
+  }
+
+  fun recordUpdated(visit: OfficialVisitEntity, previous: OfficialVisitAuditSnapshot?) {
+    val actor = actorFor(visit.updatedBy ?: visit.createdBy)
+    val before = previous ?: OfficialVisitAuditSnapshot.from(visit)
+
+    auditingService.recordAuditEvent(
+      auditVisitChangeEvent {
+        officialVisitId(visit.officialVisitId)
+        summaryText("Official visit updated")
+        eventSource(eventSource())
+        user(actor)
+        prisonCode(visit.prisonCode)
+        prisonerNumber(visit.prisonerNumber)
+        changes {
+          change("Visit slot", before.prisonVisitSlotId, visit.prisonVisitSlot.prisonVisitSlotId)
+          change("Visit date", before.visitDate, visit.visitDate)
+          change("Start time", before.startTime, visit.startTime)
+          change("End time", before.endTime, visit.endTime)
+          change("Location", before.dpsLocationId, visit.dpsLocationId)
+          change("Visit type", before.visitTypeCode, visit.visitTypeCode.name)
+          change("Prison code", before.prisonCode, visit.prisonCode)
+          change("Prisoner number", before.prisonerNumber, visit.prisonerNumber)
+          change("Current term", before.currentTerm, visit.currentTerm)
+          change("Prisoner notes", before.prisonerNotes, visit.prisonerNotes)
+          change("Staff notes", before.staffNotes, visit.staffNotes)
+          change("Visitor concern notes", before.visitorConcernNotes, visit.visitorConcernNotes)
+          change("Override ban by", before.overrideBanBy, visit.overrideBanBy)
+          change("Offender book ID", before.offenderBookId, visit.offenderBookId)
+          change("Offender visit ID", before.offenderVisitId, visit.offenderVisitId)
+          change("Visit order number", before.visitOrderNumber, visit.visitOrderNumber)
+          change("Visit status code", before.visitStatusCode, visit.visitStatusCode.name)
+          change("Visit completion code", before.completionCode, visit.completionCode?.name)
+          change("Completion notes", before.completionNotes, visit.completionNotes)
+          change("Search type code", before.searchTypeCode, visit.searchTypeCode?.name)
+        }
+      },
+    )
+  }
+
+  fun recordDeleted(visit: OfficialVisitEntity, previous: OfficialVisitAuditSnapshot?) {
+    val actor = actorFor(visit.updatedBy ?: visit.createdBy)
+    val details = previous?.let { "Official visit deleted for prisoner number ${it.prisonerNumber}" }
+      ?: "Official visit deleted for prisoner number ${visit.prisonerNumber}"
+
+    auditingService.recordAuditEvent(
+      auditVisitCreateEvent {
+        officialVisitId(visit.officialVisitId)
+        summaryText("Official visit deleted")
+        eventSource(eventSource())
+        user(actor)
+        prisonCode(visit.prisonCode)
+        prisonerNumber(visit.prisonerNumber)
+        detailsText(details)
+      },
+    )
+  }
+
+  private fun eventSource(): String = currentRequestAttributes()
+    ?.request
+    ?.requestURI
+    ?.let { if (it.startsWith("/sync/")) "NOMIS" else "DPS" }
+    ?: "DPS"
+
+  private fun actorFor(username: String?): User = requestUser()
+    ?: username?.let { userService.getUser(it) ?: ServiceUser(it, it) }
+    ?: ServiceUser("SYSTEM", "SYSTEM")
+
+  private fun requestUser(): User? = (
+    currentRequestAttributes()
+      ?.request
+      ?.getAttribute(LocalRequestContext::class.simpleName) as? LocalRequestContext
+    )?.user
+
+  private fun currentRequestAttributes(): ServletRequestAttributes? = RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrationService.kt
@@ -78,25 +78,6 @@ class MigrationService(
     )
   }
 
-  fun extractAndSaveVisitSlots(timeSlotId: Long, request: MigrateVisitConfigRequest) = request.visitSlots.map { slot ->
-    Pair(
-      slot.agencyVisitSlotId!!,
-      prisonVisitSlotRepository.saveAndFlush(
-        PrisonVisitSlotEntity(
-          prisonTimeSlotId = timeSlotId,
-          dpsLocationId = slot.dpsLocationId!!,
-          maxAdults = slot.maxAdults,
-          maxGroups = slot.maxGroups,
-          maxVideoSessions = slot.maxVideoSessions,
-          createdTime = slot.createDateTime ?: LocalDateTime.now(),
-          createdBy = slot.createUsername ?: "MIGRATION",
-          updatedTime = slot.modifyDateTime,
-          updatedBy = slot.modifyUsername,
-        ),
-      ),
-    )
-  }
-
   @Transactional(propagation = Propagation.REQUIRED)
   fun migrateVisit(request: MigrateVisitRequest): MigrateVisitResponse {
     logger.info(
@@ -127,7 +108,26 @@ class MigrationService(
     )
   }
 
-  fun extractAndSaveVisitors(dpsVisit: OfficialVisitEntity, request: MigrateVisitRequest) = request.visitors.map { visitor ->
+  private fun extractAndSaveVisitSlots(timeSlotId: Long, request: MigrateVisitConfigRequest) = request.visitSlots.map { slot ->
+    Pair(
+      slot.agencyVisitSlotId!!,
+      prisonVisitSlotRepository.saveAndFlush(
+        PrisonVisitSlotEntity(
+          prisonTimeSlotId = timeSlotId,
+          dpsLocationId = slot.dpsLocationId!!,
+          maxAdults = slot.maxAdults,
+          maxGroups = slot.maxGroups,
+          maxVideoSessions = slot.maxVideoSessions,
+          createdTime = slot.createDateTime ?: LocalDateTime.now(),
+          createdBy = slot.createUsername ?: "MIGRATION",
+          updatedTime = slot.modifyDateTime,
+          updatedBy = slot.modifyUsername,
+        ),
+      ),
+    )
+  }
+
+  private fun extractAndSaveVisitors(dpsVisit: OfficialVisitEntity, request: MigrateVisitRequest) = request.visitors.map { visitor ->
     Pair(
       visitor.offenderVisitVisitorId!!,
       officialVisitorRepository.saveAndFlush(
@@ -155,7 +155,7 @@ class MigrationService(
     )
   }
 
-  fun extractAndSavePrisonerVisited(
+  private fun extractAndSavePrisonerVisited(
     dpsVisit: OfficialVisitEntity,
     request: MigrateVisitRequest,
   ): PrisonerVisitedEntity = prisonerVisitedRepository.saveAndFlush(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitService.kt
@@ -16,9 +16,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonVisitSlotRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitChangeEvent
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCreateEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
@@ -32,7 +29,6 @@ class SyncOfficialVisitService(
   private val prisonerVisitedRepository: PrisonerVisitedRepository,
   private val prisonVisitSlotRepository: PrisonVisitSlotRepository,
   private val metricsService: MetricsService,
-  private val auditingService: AuditingService,
   private val userService: UserService,
 ) {
   @Transactional(readOnly = true)
@@ -48,7 +44,7 @@ class SyncOfficialVisitService(
   }
 
   fun createVisit(request: SyncCreateOfficialVisitRequest): SyncOfficialVisit {
-    val createdBy = userService.getUser(request.createUsername!!) ?: throw EntityNotFoundException("User ${request.createUsername} not found")
+    userService.getUser(request.createUsername!!) ?: throw EntityNotFoundException("User ${request.createUsername} not found")
 
     val visitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId!!).orElseThrow {
       EntityNotFoundException("Prison visit slot ID ${request.prisonVisitSlotId} does not exist")
@@ -89,23 +85,11 @@ class SyncOfficialVisitService(
       ),
     )
 
-    return visit.toSyncModel(prisonerVisited).also {
-      auditingService.recordAuditEvent(
-        auditVisitCreateEvent {
-          officialVisitId(visit.officialVisitId)
-          summaryText("Official visit created")
-          eventSource("NOMIS")
-          user(createdBy)
-          prisonCode(visit.prisonCode)
-          prisonerNumber(visit.prisonerNumber)
-          detailsText("Official visit created for prisoner number ${it.prisonerNumber}")
-        },
-      )
-    }
+    return visit.toSyncModel(prisonerVisited)
   }
 
   fun updateVisit(officialVisitId: Long, request: SyncUpdateOfficialVisitRequest): SyncOfficialVisit {
-    val updatedBy = userService.getUser(request.updateUsername) ?: throw EntityNotFoundException("User ${request.updateUsername} not found")
+    userService.getUser(request.updateUsername) ?: throw EntityNotFoundException("User ${request.updateUsername} not found")
 
     val visit = officialVisitRepository.findById(officialVisitId).orElseThrow {
       EntityNotFoundException("Official visit with ID $officialVisitId not found")
@@ -137,34 +121,6 @@ class SyncOfficialVisitService(
     } else {
       visit.prisonVisitSlot
     }
-
-    val auditChangeEvent = auditVisitChangeEvent {
-      officialVisitId(visit.officialVisitId)
-      summaryText("Official visit updated")
-      eventSource("NOMIS")
-      user(updatedBy)
-      prisonCode(request.prisonCode)
-      prisonerNumber(request.prisonerNumber)
-      changes {
-        change("Visit slot", visit.prisonVisitSlot.prisonVisitSlotId, request.prisonVisitSlotId)
-        change("Visit date", visit.visitDate, request.visitDate)
-        change("Start time", visit.startTime, request.startTime)
-        change("End time", visit.endTime, request.endTime)
-        change("Location", visit.dpsLocationId, request.dpsLocationId)
-        change("Prison code", visit.prisonCode, request.prisonCode)
-        change("Prisoner number", visit.prisonerNumber, request.prisonerNumber)
-        change("Prisoner notes", visit.prisonerNotes, request.commentText)
-        change("Visitor concern notes", visit.visitorConcernNotes, request.visitorConcernText)
-        change("Override ban by", visit.overrideBanBy, request.overrideBanStaffUsername)
-        change("Offender book ID", visit.offenderBookId, request.offenderBookId)
-        change("Offender visit ID", visit.offenderVisitId, request.offenderVisitId)
-        change("Visit order number", visit.visitOrderNumber, request.visitOrderNumber)
-        change("Visit status code", visit.visitStatusCode, request.visitStatusCode)
-        change("Visit completion code", visit.completionCode, request.visitCompletionCode)
-        change("Search type code", visit.searchTypeCode, request.searchTypeCode)
-      }
-    }
-
     visit.apply {
       prisonVisitSlot = visitSlot
       visitDate = request.visitDate
@@ -200,14 +156,12 @@ class SyncOfficialVisitService(
       )
     }
 
-    auditingService.recordAuditEvent(auditChangeEvent)
-
     return savedVisit.toSyncModel(prisonerVisited)
   }
 
   fun deleteVisit(officialVisitId: Long) = officialVisitRepository.findByIdOrNull(officialVisitId)?.also { officialVisit ->
     officialVisitorRepository.deleteByOfficialVisit(officialVisit)
     prisonerVisitedRepository.deleteByOfficialVisit(officialVisit)
-    officialVisitRepository.deleteById(officialVisit.officialVisitId)
+    officialVisitRepository.delete(officialVisit)
   }?.toSyncModel()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitorService.kt
@@ -17,8 +17,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.VisitorEquipmentRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.ContactsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCreateEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
@@ -34,7 +32,6 @@ class SyncOfficialVisitorService(
   private val contactsService: ContactsService,
   private val visitorEquipmentRepository: VisitorEquipmentRepository,
   private val metricsService: MetricsService,
-  private val auditingService: AuditingService,
   private val userService: UserService,
 ) {
   companion object {
@@ -102,19 +99,7 @@ class SyncOfficialVisitorService(
       prisonCode = visit.prisonCode,
       prisonerNumber = visit.prisonerNumber,
       visitor = visitorSaved.toSyncModel(),
-    ).also {
-      auditingService.recordAuditEvent(
-        auditVisitCreateEvent {
-          officialVisitId(visit.officialVisitId)
-          summaryText("${visitorSaved.relationshipType()} visitor added")
-          eventSource("NOMIS")
-          user(createdBy)
-          prisonCode(visit.prisonCode)
-          prisonerNumber(visit.prisonerNumber)
-          detailsText("${visitorSaved.relationshipType()} visitor ${visitorSaved.name()} added to visit for prisoner number ${it.prisonerNumber}")
-        },
-      )
-    }
+    )
   }
 
   private fun OfficialVisitorEntity.name() = "${firstName?.replaceFirstChar { it.uppercase() }} ${lastName?.replaceFirstChar { it.uppercase() }}"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
@@ -97,10 +97,11 @@ abstract class IntegrationTestBase {
   }
 
   protected fun clearAllVisitData() {
-    auditedEventRepository.deleteAll()
+    // IMPORTANT: audit events must be deleted LAST.
     prisonerVisitedRepository.deleteAll()
     officialVisitorRepository.deleteAll()
     officialVisitRepository.deleteAll()
+    auditedEventRepository.deleteAll()
   }
 
   protected fun prisonerSearchApi() = PrisonerSearchApiExtension.server

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCancellationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCancellationIntegrationTest.kt
@@ -177,6 +177,22 @@ class OfficialVisitCancellationIntegrationTest : IntegrationTestBase() {
       eventSource isEqualTo Source.DPS.name
       eventDateTime isCloseTo now()
     }
+
+    // Assert the entity listener @PostUpdate generated an "Official visit updated" audit event
+    with(auditedEventRepository.findAll().single { it.summaryText == "Official visit updated" }) {
+      officialVisitId isEqualTo cancelledVisit.officialVisitId
+      prisonCode isEqualTo MOORLAND
+      prisonerNumber isEqualTo MOORLAND_PRISONER.number
+      userName isEqualTo MOORLAND_PRISON_USER.username
+      userFullName isEqualTo MOORLAND_PRISON_USER.name
+      eventSource isEqualTo Source.DPS.name
+      eventDateTime isCloseTo now()
+      // Detail text should describe the status and completion code changes recorded on cancel
+      detailText.contains("Visit status code changed from SCHEDULED to CANCELLED") isEqualTo true
+    }
+
+    // Total: "Official visit created" + "Official visit updated" (entity listener) + "Official visit cancelled"
+    auditedEventRepository.findAll() hasSize 3
   }
 
   private fun WebTestClient.cancel(officialVisitId: Long, request: OfficialVisitCancellationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCompletionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCompletionIntegrationTest.kt
@@ -187,6 +187,22 @@ class OfficialVisitCompletionIntegrationTest : IntegrationTestBase() {
       eventSource isEqualTo Source.DPS.name
       eventDateTime isCloseTo now()
     }
+
+    // Assert the entity listener @PostUpdate generated an "Official visit updated" audit event
+    with(auditedEventRepository.findAll().single { it.summaryText == "Official visit updated" }) {
+      officialVisitId isEqualTo completedVisit.officialVisitId
+      prisonCode isEqualTo MOORLAND
+      prisonerNumber isEqualTo MOORLAND_PRISONER.number
+      userName isEqualTo MOORLAND_PRISON_USER.username
+      userFullName isEqualTo MOORLAND_PRISON_USER.name
+      eventSource isEqualTo Source.DPS.name
+      eventDateTime isCloseTo now()
+      // Detail text should describe the status and completion code changes recorded on complete
+      detailText.contains("Visit status code changed from SCHEDULED to COMPLETED") isEqualTo true
+    }
+
+    // Total: "Official visit created" + "Official visit updated" (entity listener) + "Official visit completed"
+    auditedEventRepository.findAll() hasSize 3
   }
 
   private fun WebTestClient.complete(officialVisitId: Long, request: OfficialVisitCompletionRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitUpdateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitUpdateIntegrationTest.kt
@@ -438,9 +438,20 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
 
     val auditEvents = auditedEventRepository.findAll()
 
-    auditEvents hasSize 2
+    auditEvents hasSize 3
 
     auditEvents.single { it.summaryText == "Official visit created" }
+
+    with(auditEvents.single { it.summaryText == "Official visitor added" }) {
+      officialVisitId isEqualTo result.officialVisitId
+      prisonCode isEqualTo MOORLAND
+      prisonerNumber isEqualTo MOORLAND_PRISONER.number
+      detailText isEqualTo "Official visitor John Doe added to visit for prisoner number ${MOORLAND_PRISONER.number}"
+      userName isEqualTo MOORLAND_PRISON_USER.username
+      userFullName isEqualTo MOORLAND_PRISON_USER.name
+      eventSource isEqualTo Source.DPS.name
+      eventDateTime isCloseTo now()
+    }
 
     with(auditEvents.single { it.summaryText == "Update visit visitors" }) {
       officialVisitId isEqualTo result.officialVisitId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitUpdateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitUpdateIntegrationTest.kt
@@ -162,6 +162,24 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
       dpsLocationId isEqualTo location.id
       visitTypeCode isEqualTo VisitType.VIDEO
     }
+
+    // Assert entity-listener audit events: one for create (from @BeforeEach) and one for this update
+    val auditEvents = auditedEventRepository.findAll()
+    auditEvents hasSize 2
+    auditEvents.single { it.summaryText == "Official visit created" }
+    with(auditEvents.single { it.summaryText == "Official visit updated" }) {
+      officialVisitId isEqualTo scheduledVisit?.officialVisitId!!
+      prisonCode isEqualTo MOORLAND
+      prisonerNumber isEqualTo MOORLAND_PRISONER.number
+      userName isEqualTo MOORLAND_PRISON_USER.username
+      userFullName isEqualTo MOORLAND_PRISON_USER.name
+      eventSource isEqualTo Source.DPS.name
+      eventDateTime isCloseTo now()
+      // Detail text should describe the specific field changes
+      detailText.contains("Start time changed from 09:00 to 10:00") isEqualTo true
+      detailText.contains("End time changed from 10:00 to 11:00") isEqualTo true
+      detailText.contains("Visit type changed from IN_PERSON to VIDEO") isEqualTo true
+    }
   }
 
   @Test
@@ -195,6 +213,23 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
     with(result) {
       staffNotes isEqualTo "New staff notes"
       prisonerNotes isEqualTo "New prisoner notes"
+    }
+
+    // Assert entity-listener audit events: one for create (from @BeforeEach) and one for this update
+    val auditEvents = auditedEventRepository.findAll()
+    auditEvents hasSize 2
+    auditEvents.single { it.summaryText == "Official visit created" }
+    with(auditEvents.single { it.summaryText == "Official visit updated" }) {
+      officialVisitId isEqualTo scheduledVisit?.officialVisitId!!
+      prisonCode isEqualTo MOORLAND
+      prisonerNumber isEqualTo MOORLAND_PRISONER.number
+      userName isEqualTo MOORLAND_PRISON_USER.username
+      userFullName isEqualTo MOORLAND_PRISON_USER.name
+      eventSource isEqualTo Source.DPS.name
+      eventDateTime isCloseTo now()
+      // Detail text should describe the specific field changes
+      detailText.contains("Prisoner notes changed from public notes to New prisoner notes") isEqualTo true
+      detailText.contains("Staff notes changed from private notes to New staff notes") isEqualTo true
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
@@ -174,6 +174,13 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
       ),
       personReference = PersonReference(nomsNumber = response.prisonerNumber),
     )
+
+    assertThat(auditedEventRepository.findAll())
+      .anySatisfy {
+        assertThat(it.officialVisitId).isEqualTo(response.officialVisitId)
+        assertThat(it.summaryText).isEqualTo("Official visit created")
+        assertThat(it.eventSource).isEqualTo(Source.NOMIS.name)
+      }
   }
 
   @Test
@@ -277,6 +284,13 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
       ),
       personReference = PersonReference(nomsNumber = updateResponse.prisonerNumber),
     )
+
+    assertThat(auditedEventRepository.findAll())
+      .anySatisfy {
+        assertThat(it.officialVisitId).isEqualTo(updateResponse.officialVisitId)
+        assertThat(it.summaryText).isEqualTo("Official visit updated")
+        assertThat(it.eventSource).isEqualTo(Source.NOMIS.name)
+      }
   }
 
   @Test
@@ -377,6 +391,13 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
         nomsNumber = officialVisit.prisonerNumber,
       ),
     )
+
+    assertThat(auditedEventRepository.findAll())
+      .anySatisfy {
+        assertThat(it.officialVisitId).isEqualTo(officialVisit.officialVisitId)
+        assertThat(it.summaryText).isEqualTo("Official visit deleted")
+        assertThat(it.eventSource).isEqualTo(Source.NOMIS.name)
+      }
   }
 
   private fun SyncOfficialVisit.assertWithCreateRequest(request: CreateOfficialVisitRequest) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
@@ -13,8 +13,12 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.CONTACT_MOORLAND_PR
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.hasSize
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isCloseTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.next
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.now
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.today
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
@@ -164,6 +168,20 @@ class SyncOfficialVisitorsIntegrationTest : IntegrationTestBase() {
         contactId = contactId,
       ),
     )
+
+    val auditEvents = auditedEventRepository.findAll()
+    auditEvents hasSize 2
+
+    with(auditEvents.single { it.summaryText == "Official visitor added" }) {
+      officialVisitId isEqualTo savedOfficialVisitId
+      prisonCode isEqualTo MOORLAND
+      prisonerNumber isEqualTo MOORLAND_PRISONER.number
+      detailText isEqualTo "Official visitor First Last added to visit for prisoner number ${MOORLAND_PRISONER.number}"
+      userName isEqualTo MOORLAND_PRISON_USER.username
+      userFullName isEqualTo MOORLAND_PRISON_USER.name
+      eventSource isEqualTo Source.NOMIS.name
+      eventDateTime isCloseTo now()
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitUpdateServiceTest.kt
@@ -15,7 +15,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toMediumFormatStyle
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitorEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.PrisonVisitSlotEntity
@@ -24,9 +23,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.contains
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isCloseTo
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.now
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
 import uk.gov.justice.digital.hmpps.officialvisitsapi.mapping.toPrisonerContactModel
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.RelationshipType
@@ -39,7 +35,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisi
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitorRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonVisitSlotRepository
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditEventDto
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
 import java.time.LocalDate
@@ -87,12 +82,6 @@ class OfficialVisitUpdateServiceTest {
     whenever(prisonVisitSlotRepository.findById(99L)).thenReturn(Optional.of(newSlot))
     whenever(officialVisitRepository.saveAndFlush(any<OfficialVisitEntity>())).thenAnswer { it.arguments[0] as OfficialVisitEntity }
 
-    val oldDpsLocationId = visit.dpsLocationId
-    val oldVisitTypeCode = visit.visitTypeCode
-    val oldVisitDate = visit.visitDate
-    val oldStartTime = visit.startTime
-    val oldEndTime = visit.endTime
-
     val response = service.updateVisitTypeAndSlot(11L, MOORLAND, request, MOORLAND_PRISON_USER)
 
     assertThat(response.officialVisitId).isEqualTo(11L)
@@ -106,21 +95,6 @@ class OfficialVisitUpdateServiceTest {
     assertThat(visit.updatedBy).isEqualTo(MOORLAND_PRISON_USER.username)
     assertThat(visit.updatedTime).isNotNull
     verify(officialVisitRepository).saveAndFlush(visit)
-
-    val auditEventCaptor = argumentCaptor<AuditEventDto>()
-    verify(auditingService).recordAuditEvent(auditEventCaptor.capture())
-
-    with(auditEventCaptor.firstValue) {
-      officialVisitId isEqualTo 11
-      prisonerNumber isEqualTo MOORLAND_PRISONER.number
-      prisonCode isEqualTo MOORLAND
-      eventSource isEqualTo "DPS"
-      username isEqualTo MOORLAND_PRISON_USER.username
-      userFullName isEqualTo MOORLAND_PRISON_USER.name
-      summaryText isEqualTo "Update visit visit type and visit slot"
-      detailText isEqualTo "Visit date changed from ${oldVisitDate.toMediumFormatStyle()} to ${request.visitDate?.toMediumFormatStyle()}; Start time changed from $oldStartTime to ${request.startTime}; End time changed from $oldEndTime to ${request.endTime}; Location changed from $oldDpsLocationId to ${request.dpsLocationId}; Visit type changed from $oldVisitTypeCode to VIDEO; Visit slot changed from 1 to 99."
-      eventDateTime isCloseTo now()
-    }
   }
 
   @Test
@@ -181,21 +155,6 @@ class OfficialVisitUpdateServiceTest {
     assertThat(visit.updatedBy).isEqualTo(MOORLAND_PRISON_USER.username)
     assertThat(visit.updatedTime).isNotNull
     verify(officialVisitRepository, times(1)).saveAndFlush(visit)
-
-    val auditEventCaptor = argumentCaptor<AuditEventDto>()
-    verify(auditingService).recordAuditEvent(auditEventCaptor.capture())
-
-    with(auditEventCaptor.firstValue) {
-      officialVisitId isEqualTo 7
-      prisonerNumber isEqualTo MOORLAND_PRISONER.number
-      prisonCode isEqualTo MOORLAND
-      eventSource isEqualTo "DPS"
-      username isEqualTo MOORLAND_PRISON_USER.username
-      userFullName isEqualTo MOORLAND_PRISON_USER.name
-      summaryText isEqualTo "Update visit comments"
-      detailText isEqualTo "Prisoner notes changed from '' to prisoner updated; Staff notes changed from '' to staff updated."
-      eventDateTime isCloseTo now()
-    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitAuditDelegateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitAuditDelegateTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitAuditSnapshot
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.PrisonVisitSlotEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.UUID
+
+class OfficialVisitAuditDelegateTest {
+  private val auditingService: AuditingService = mock()
+  private val userService: UserService = mock()
+
+  private val delegate = OfficialVisitAuditDelegate(auditingService, userService)
+
+  @Test
+  fun `recordCreated creates create audit event`() {
+    val visit = createVisit()
+    whenever(userService.getUser(visit.createdBy)).thenReturn(MOORLAND_PRISON_USER)
+
+    delegate.recordCreated(visit)
+
+    val captor = argumentCaptor<AuditEventDto>()
+    verify(auditingService).recordAuditEvent(captor.capture())
+
+    with(captor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(visit.officialVisitId)
+      assertThat(summaryText).isEqualTo("Official visit created")
+      assertThat(prisonCode).isEqualTo(MOORLAND)
+      assertThat(prisonerNumber).isEqualTo(MOORLAND_PRISONER.number)
+      assertThat(eventSource).isEqualTo("DPS")
+    }
+  }
+
+  @Test
+  fun `recordUpdated creates update audit event with field changes`() {
+    val visit = createVisit()
+    val snapshot = OfficialVisitAuditSnapshot.from(visit)
+    whenever(userService.getUser(visit.createdBy)).thenReturn(MOORLAND_PRISON_USER)
+
+    visit.staffNotes = "updated staff notes"
+    visit.startTime = LocalTime.of(11, 0)
+    visit.updatedBy = visit.createdBy
+
+    delegate.recordUpdated(visit, snapshot)
+
+    val captor = argumentCaptor<AuditEventDto>()
+    verify(auditingService).recordAuditEvent(captor.capture())
+
+    with(captor.firstValue) {
+      assertThat(summaryText).isEqualTo("Official visit updated")
+      assertThat(detailText).contains("Start time changed from 09:00 to 11:00")
+      assertThat(detailText).contains("Staff notes changed from '' to updated staff notes")
+    }
+  }
+
+  @Test
+  fun `recordDeleted creates delete audit event`() {
+    val visit = createVisit()
+    whenever(userService.getUser(visit.createdBy)).thenReturn(MOORLAND_PRISON_USER)
+
+    delegate.recordDeleted(visit, OfficialVisitAuditSnapshot.from(visit))
+
+    val captor = argumentCaptor<AuditEventDto>()
+    verify(auditingService).recordAuditEvent(captor.capture())
+
+    with(captor.firstValue) {
+      assertThat(summaryText).isEqualTo("Official visit deleted")
+      assertThat(detailText).contains(MOORLAND_PRISONER.number)
+      assertThat(eventSource).isEqualTo("DPS")
+    }
+  }
+
+  private fun createVisit() = OfficialVisitEntity(
+    officialVisitId = 101L,
+    prisonVisitSlot = PrisonVisitSlotEntity(
+      prisonVisitSlotId = 1L,
+      prisonTimeSlotId = 1L,
+      dpsLocationId = UUID.randomUUID(),
+      createdBy = "TEST",
+      createdTime = LocalDateTime.now().minusDays(1),
+    ),
+    prisonCode = MOORLAND,
+    prisonerNumber = MOORLAND_PRISONER.number,
+    visitDate = LocalDate.now().plusDays(10),
+    startTime = LocalTime.of(9, 0),
+    endTime = LocalTime.of(10, 0),
+    dpsLocationId = UUID.randomUUID(),
+    visitTypeCode = VisitType.IN_PERSON,
+    createdBy = MOORLAND_PRISON_USER.username,
+    createdTime = LocalDateTime.now().minusDays(1),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitorAuditDelegateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/OfficialVisitorAuditDelegateTest.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitorEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.PrisonVisitSlotEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.RelationshipType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.UUID
+
+class OfficialVisitorAuditDelegateTest {
+  private val auditingService: AuditingService = mock()
+  private val userService: UserService = mock()
+
+  private val delegate = OfficialVisitorAuditDelegate(auditingService, userService)
+
+  @Test
+  fun `recordCreated creates visitor added audit event`() {
+    val visit = createVisit()
+    val visitor = OfficialVisitorEntity(
+      officialVisitorId = 201L,
+      officialVisit = visit,
+      visitorTypeCode = VisitorType.CONTACT,
+      firstName = "jane",
+      lastName = "doe",
+      contactId = 3001L,
+      prisonerContactId = 4001L,
+      relationshipTypeCode = RelationshipType.OFFICIAL,
+      relationshipCode = "POM",
+      createdBy = MOORLAND_PRISON_USER.username,
+      createdTime = LocalDateTime.now().minusHours(1),
+    )
+    whenever(userService.getUser(visitor.createdBy)).thenReturn(MOORLAND_PRISON_USER)
+
+    delegate.recordCreated(visitor)
+
+    val captor = argumentCaptor<AuditEventDto>()
+    verify(auditingService).recordAuditEvent(captor.capture())
+
+    with(captor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(visit.officialVisitId)
+      assertThat(summaryText).isEqualTo("Official visitor added")
+      assertThat(detailText).isEqualTo("Official visitor Jane Doe added to visit for prisoner number ${MOORLAND_PRISONER.number}")
+      assertThat(prisonCode).isEqualTo(MOORLAND)
+      assertThat(prisonerNumber).isEqualTo(MOORLAND_PRISONER.number)
+      assertThat(username).isEqualTo(MOORLAND_PRISON_USER.username)
+      assertThat(userFullName).isEqualTo(MOORLAND_PRISON_USER.name)
+      assertThat(eventSource).isEqualTo("DPS")
+    }
+  }
+
+  private fun createVisit() = OfficialVisitEntity(
+    officialVisitId = 101L,
+    prisonVisitSlot = PrisonVisitSlotEntity(
+      prisonVisitSlotId = 1L,
+      prisonTimeSlotId = 1L,
+      dpsLocationId = UUID.randomUUID(),
+      createdBy = "TEST",
+      createdTime = LocalDateTime.now().minusDays(1),
+    ),
+    prisonCode = MOORLAND,
+    prisonerNumber = MOORLAND_PRISONER.number,
+    visitDate = LocalDate.now().plusDays(10),
+    startTime = LocalTime.of(9, 0),
+    endTime = LocalTime.of(10, 0),
+    dpsLocationId = UUID.randomUUID(),
+    visitTypeCode = VisitType.IN_PERSON,
+    createdBy = MOORLAND_PRISON_USER.username,
+    createdTime = LocalDateTime.now().minusDays(1),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrateVisitServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrateVisitServiceTest.kt
@@ -152,56 +152,6 @@ class MigrateVisitServiceTest {
       }
     }
 
-    @Test
-    fun `should extract and save two visit slots from the request`() {
-      val request = migrateVisitConfigRequest(prisonCode = "LEI", dayCode = "MON", timeSlotSeq = 2)
-
-      val visitSlotEntities = visitSlotEntities(request)
-
-      whenever(prisonVisitSlotRepository.saveAndFlush(any<PrisonVisitSlotEntity>()))
-        .thenReturn(visitSlotEntities[0])
-        .thenReturn(visitSlotEntities[1])
-
-      val visitSlotCaptor = argumentCaptor<PrisonVisitSlotEntity>()
-
-      val result = migrationService.extractAndSaveVisitSlots(1L, request)
-
-      assertThat(result.size).isEqualTo(2)
-
-      for (i in 0..1) {
-        assertThat(result[i].first).isEqualTo(request.visitSlots[i].agencyVisitSlotId)
-        assertThat(result[i].second)
-          .extracting("prisonTimeSlotId", "dpsLocationId", "maxAdults", "maxGroups", "maxVideoSessions", "createdBy", "createdTime")
-          .contains(
-            visitSlotEntities[i].prisonTimeSlotId,
-            visitSlotEntities[i].dpsLocationId,
-            visitSlotEntities[i].maxAdults,
-            visitSlotEntities[i].maxGroups,
-            visitSlotEntities[i].maxVideoSessions,
-            visitSlotEntities[i].createdBy,
-            visitSlotEntities[i].createdTime,
-          )
-      }
-
-      verify(prisonVisitSlotRepository, times(2)).saveAndFlush(visitSlotCaptor.capture())
-
-      for (i in 0..1) {
-        with(visitSlotCaptor.allValues[i]) {
-          assertThat(this)
-            .extracting("prisonTimeSlotId", "dpsLocationId", "maxAdults", "maxGroups", "maxVideoSessions", "createdBy", "createdTime")
-            .contains(
-              visitSlotEntities[i].prisonTimeSlotId,
-              visitSlotEntities[i].dpsLocationId,
-              visitSlotEntities[i].maxAdults,
-              visitSlotEntities[i].maxGroups,
-              visitSlotEntities[i].maxVideoSessions,
-              visitSlotEntities[i].createdBy,
-              visitSlotEntities[i].createdTime,
-            )
-        }
-      }
-    }
-
     private fun migrateVisitConfigRequest(prisonCode: String, dayCode: String, timeSlotSeq: Int) = MigrateVisitConfigRequest(
       prisonCode = prisonCode,
       dayCode = dayCode,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitServiceTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.reset
@@ -25,9 +24,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAPrisonerVisitedEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isCloseTo
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.now
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitStatusType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync.SyncCreateOfficialVisitRequest
@@ -38,8 +34,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonVisitSlotRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditEventDto
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
@@ -55,7 +49,6 @@ class SyncOfficialVisitServiceTest {
   private val prisonerVisitedRepository: PrisonerVisitedRepository = mock()
   private val prisonVisitSlotRepository: PrisonVisitSlotRepository = mock()
   private val metricsService: MetricsService = mock()
-  private val auditingService: AuditingService = mock()
   private val userService: UserService = mock()
 
   private val createdTime = LocalDateTime.now().minusDays(2)
@@ -66,7 +59,6 @@ class SyncOfficialVisitServiceTest {
     prisonerVisitedRepository,
     prisonVisitSlotRepository,
     metricsService,
-    auditingService,
     userService,
   )
 
@@ -166,21 +158,6 @@ class SyncOfficialVisitServiceTest {
         locationType = null,
       ),
     )
-
-    val auditEventCaptor = argumentCaptor<AuditEventDto>()
-    verify(auditingService).recordAuditEvent(auditEventCaptor.capture())
-
-    with(auditEventCaptor.firstValue) {
-      officialVisitId isEqualTo 0
-      prisonerNumber isEqualTo MOORLAND_PRISONER.number
-      prisonCode isEqualTo MOORLAND
-      eventSource isEqualTo "NOMIS"
-      username isEqualTo MOORLAND_PRISON_USER.username
-      userFullName isEqualTo MOORLAND_PRISON_USER.name
-      summaryText isEqualTo "Official visit created"
-      detailText isEqualTo "Official visit created for prisoner number ${MOORLAND_PRISONER.number}"
-      eventDateTime isCloseTo now()
-    }
   }
 
   @Test
@@ -283,21 +260,6 @@ class SyncOfficialVisitServiceTest {
         locationType = null,
       ),
     )
-
-    val auditEventCaptor = argumentCaptor<AuditEventDto>()
-    verify(auditingService).recordAuditEvent(auditEventCaptor.capture())
-
-    with(auditEventCaptor.firstValue) {
-      this.officialVisitId isEqualTo 0
-      prisonerNumber isEqualTo MOORLAND_PRISONER.number
-      prisonCode isEqualTo MOORLAND
-      eventSource isEqualTo "NOMIS"
-      username isEqualTo MOORLAND_PRISON_USER.username
-      userFullName isEqualTo MOORLAND_PRISON_USER.name
-      summaryText isEqualTo "Official visit updated"
-      detailText isEqualTo "Start time changed from 09:00 to 10:00; End time changed from 10:00 to 11:00; Prisoner notes changed from '' to updated comment; Visitor concern notes changed from '' to updated concern; Offender visit ID changed from 1 to 2; Visit order number changed from '' to 5678; Visit status code changed from SCHEDULED to EXPIRED."
-      eventDateTime isCloseTo now()
-    }
   }
 
   @Test
@@ -338,7 +300,7 @@ class SyncOfficialVisitServiceTest {
     verify(officialVisitRepository).findById(1L)
     verify(prisonerVisitedRepository).deleteByOfficialVisit(visitEntity)
     verify(officialVisitorRepository).deleteByOfficialVisit(visitEntity)
-    verify(officialVisitRepository).deleteById(1L)
+    verify(officialVisitRepository).delete(visitEntity)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitorServiceTest.kt
@@ -25,9 +25,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.exception.EntityInUseExcep
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.now
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.tomorrow
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.RelationshipType
@@ -40,8 +38,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.VisitorEquipmentRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.ContactsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditEventDto
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
@@ -57,7 +53,6 @@ class SyncOfficialVisitorServiceTest {
   private val contactsService: ContactsService = mock()
   private val visitorEquipmentRepository: VisitorEquipmentRepository = mock()
   private val metricsService: MetricsService = mock()
-  private val auditingService: AuditingService = mock()
   private val userService: UserService = mock()
 
   private val createdTime = LocalDateTime.now().minusDays(2)
@@ -68,7 +63,6 @@ class SyncOfficialVisitorServiceTest {
     contactsService,
     visitorEquipmentRepository,
     metricsService,
-    auditingService,
     userService,
   )
 
@@ -79,7 +73,7 @@ class SyncOfficialVisitorServiceTest {
 
   @AfterEach
   fun afterEach() {
-    reset(officialVisitRepository, officialVisitorRepository, contactsService, visitorEquipmentRepository, metricsService, auditingService)
+    reset(officialVisitRepository, officialVisitorRepository, contactsService, visitorEquipmentRepository, metricsService, userService)
   }
 
   @Test
@@ -135,20 +129,6 @@ class SyncOfficialVisitorServiceTest {
         officialVisitorId = result.visitor.officialVisitorId,
       ),
     )
-    val auditEventCaptor = argumentCaptor<AuditEventDto>()
-    verify(auditingService).recordAuditEvent(auditEventCaptor.capture())
-
-    with(auditEventCaptor.firstValue) {
-      officialVisitId isEqualTo 0
-      prisonerNumber isEqualTo MOORLAND_PRISONER.number
-      prisonCode isEqualTo MOORLAND
-      eventSource isEqualTo "NOMIS"
-      username isEqualTo MOORLAND_PRISON_USER.username
-      userFullName isEqualTo MOORLAND_PRISON_USER.name
-      summaryText isEqualTo "Official visitor added"
-      detailText isEqualTo "Official visitor First Last added to visit for prisoner number ${MOORLAND_PRISONER.number}"
-      eventDateTime isCloseTo now()
-    }
     verify(metricsService).send(
       MetricsEvents.ADD_VISITOR,
       VisitorMetricInfo(


### PR DESCRIPTION
This pull request introduces a new Hibernate entity listener-based auditing mechanism for `OfficialVisitEntity`, moving audit logic out of the service layer and centralizing it in a dedicated listener. It also refactors related code to support this new approach and makes minor improvements to repository usage and code structure.

**Auditing improvements:**

* Added a new `OfficialVisitAuditEntityListener` class that uses Hibernate entity lifecycle events (`@PostLoad`, `@PostPersist`, `@PostUpdate`, `@PreRemove`) to automatically capture and record audit events for `OfficialVisitEntity`. This listener uses an `OfficialVisitAuditSnapshot` data class to track changes and interacts with a delegate to call the auditing service. (`[[1]](diffhunk://#diff-56520c8e55e155a9761eac4a169c4c72d0b70b7980e61366b3e32cd64dfcf8b1R1-R147)`, `[[2]](diffhunk://#diff-139878f4a96b2e6b294c9b149b7d5c6b975728b72de4c247124a12ab5c99feecR1-R54)`)
* Registered the entity listener on `OfficialVisitEntity` via the `@EntityListeners` annotation and added a transient `auditSnapshot` property to hold the snapshot between events. (`[[1]](diffhunk://#diff-32c6a3c0c97cd57c3cd7c5f32601fd72b248bd142da936fea092ac13a9655d84R38)`, `[[2]](diffhunk://#diff-32c6a3c0c97cd57c3cd7c5f32601fd72b248bd142da936fea092ac13a9655d84R85-R87)`)
* Removed manual calls to the auditing service from `OfficialVisitCreateService`, `OfficialVisitUpdateService`, and `SyncOfficialVisitService`, as auditing is now handled automatically by the listener. (`[[1]](diffhunk://#diff-727afc247150522a6d61274146c8ef3b1489617212b5d9953df083221b7dc85bL22-L23)`, `[[2]](diffhunk://#diff-727afc247150522a6d61274146c8ef3b1489617212b5d9953df083221b7dc85bL42)`, `[[3]](diffhunk://#diff-727afc247150522a6d61274146c8ef3b1489617212b5d9953df083221b7dc85bL97-L110)`, `[[4]](diffhunk://#diff-2cb33be44aabf6b566880c94c26e857f2a0de528aeb76c4619fb84dd85998708L58-L74)`, `[[5]](diffhunk://#diff-2cb33be44aabf6b566880c94c26e857f2a0de528aeb76c4619fb84dd85998708L100-L101)`, `[[6]](diffhunk://#diff-2cb33be44aabf6b566880c94c26e857f2a0de528aeb76c4619fb84dd85998708L121-L133)`, `[[7]](diffhunk://#diff-c71eeddc059e24149e990ce7ffc9d0f2251960dd303a883a547ceed26d9ef894L19-L21)`)

**Repository and code structure improvements:**

* Changed the auditing service to use `save()` instead of `saveAndFlush()` to avoid recursive Hibernate flushes, improving stability. (`[src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingService.ktL15-R16](diffhunk://#diff-a57c75238b93e3977a3f64c55a0b9daffe7a9b5a0179f0285a2a6586a02d1637L15-R16)`)
* Refactored migration logic in `MigrationService` by making helper methods private and improving encapsulation. (`[[1]](diffhunk://#diff-4a8f78b77762d89affc035eb64c7ef584f9326ff67d725f179bd7ed4f3624cbdL80-L98)`, `[[2]](diffhunk://#diff-4a8f78b77762d89affc035eb64c7ef584f9326ff67d725f179bd7ed4f3624cbdL129-R129)`, `[[3]](diffhunk://#diff-4a8f78b77762d89affc035eb64c7ef584f9326ff67d725f179bd7ed4f3624cbdL157-R157)`)

These changes centralize and automate audit event recording, reduce duplication, and improve maintainability and reliability of the codebase.

**Test evidence for create and update visits**
<img width="1653" height="82" alt="image" src="https://github.com/user-attachments/assets/dd419d56-6cb3-4da2-b59c-eada914c4862" />
