### PR TITLE
OV-532 disable call to personal relationships api for search.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitSearchService.kt
@@ -97,7 +97,9 @@ class OfficialVisitSearchService(
     // Get the locations for visits for this prison (it's a cacheable endpoint)
     val locations = locationsInsidePrisonClient.getOfficialVisitLocationsAtPrison(prisonCode)
     val locationMap = locations.map { LocationDescription(it.id, it.localName, it.locationType, it.key) }.associateBy { it.id }
-    val visitIdsWithIssues = visitsWithApprovalIssues.identify(prisonCode, results.content.visitsScheduleAfter(LocalDateTime.now()).map { it.officialVisitId })
+    // TODO temporary disable until we can re-enable this
+//    val visitIdsWithIssues = visitsWithApprovalIssues.identify(prisonCode, results.content.visitsScheduleAfter(LocalDateTime.now()).map { it.officialVisitId })
+    val visitIdsWithIssues = emptySet<Long>()
 
     // Enrich the page of results
     val response = results.map { ov ->


### PR DESCRIPTION
There is a problem with the token set to the personal relationships API so comment out the call to it in the search code for now until we have fix.