### PR TITLE
Revert "OV-532 disable call to personal relationships api for search."

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitSearchService.kt
@@ -97,9 +97,7 @@ class OfficialVisitSearchService(
     // Get the locations for visits for this prison (it's a cacheable endpoint)
     val locations = locationsInsidePrisonClient.getOfficialVisitLocationsAtPrison(prisonCode)
     val locationMap = locations.map { LocationDescription(it.id, it.localName, it.locationType, it.key) }.associateBy { it.id }
-    // TODO temporary disable until we can re-enable this
-//    val visitIdsWithIssues = visitsWithApprovalIssues.identify(prisonCode, results.content.visitsScheduleAfter(LocalDateTime.now()).map { it.officialVisitId })
-    val visitIdsWithIssues = emptySet<Long>()
+    val visitIdsWithIssues = visitsWithApprovalIssues.identify(prisonCode, results.content.visitsScheduleAfter(LocalDateTime.now()).map { it.officialVisitId })
 
     // Enrich the page of results
     val response = results.map { ov ->


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-official-visits-api#168

Should be OK to revert as the issues with the personal relationships API have now been resolved.