### PR TITLE
OV-543: Booking move event handler updates and bug fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/PrisonerVisitedRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/PrisonerVisitedRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.PrisonerVisitedEntity
+import java.time.LocalDateTime
 
 @Repository
 interface PrisonerVisitedRepository : JpaRepository<PrisonerVisitedEntity, Long> {
@@ -34,6 +35,18 @@ interface PrisonerVisitedRepository : JpaRepository<PrisonerVisitedEntity, Long>
   )
   @Modifying
   fun replacePrisonerNumber(removedNumber: String, replacementNumber: String)
+
+  @Query(
+    value = """
+    UPDATE PrisonerVisitedEntity pv 
+    SET pv.prisonerNumber = :replacementNumber 
+    WHERE pv.prisonerNumber = :removedNumber
+    AND pv.officialVisit.offenderBookId = :bookingId
+    AND pv.officialVisit.createdTime > :startDateTime
+    """,
+  )
+  @Modifying
+  fun replacePrisonerNumberForBooking(removedNumber: String, replacementNumber: String, bookingId: Long, startDateTime: LocalDateTime)
 
   @Query(
     value = """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
@@ -35,7 +35,6 @@ class PrisonerReceivedEvent(additionalInformation: ReceivedInformation) : Domain
 data class ReceivedInformation(val nomsNumber: String, val reason: String, val prisonId: String) : AdditionalInformation
 
 class PrisonerReleasedEvent(additionalInformation: ReleaseInformation) : DomainEvent<ReleaseInformation>(DomainEventType.PRISONER_RELEASED, additionalInformation) {
-
   @JsonIgnore
   fun prisonerNumber() = additionalInformation.nomsNumber
 
@@ -62,13 +61,20 @@ class PrisonerMergedEvent(additionalInformation: MergeInformation) : DomainEvent
 data class MergeInformation(val nomsNumber: String, val removedNomsNumber: String) : AdditionalInformation
 
 class PrisonerBookingMovedEvent(additionalInformation: BookingMovedInformation) : DomainEvent<BookingMovedInformation>(DomainEventType.PRISONER_BOOKING_MOVED, additionalInformation) {
+  @JsonIgnore
   fun movedFromNomsNumber() = additionalInformation.movedFromNomsNumber
+
+  @JsonIgnore
   fun movedToNomsNumber() = additionalInformation.movedToNomsNumber
+
+  @JsonIgnore
   fun bookingId() = additionalInformation.bookingId
-  fun startDateTime() = additionalInformation.startDateTime
+
+  @JsonIgnore
+  fun bookingStartDateTime() = additionalInformation.bookingStartDateTime
 }
 
-data class BookingMovedInformation(val movedFromNomsNumber: String, val movedToNomsNumber: String, val bookingId: Long, val startDateTime: LocalDateTime) : AdditionalInformation
+data class BookingMovedInformation(val movedFromNomsNumber: String, val movedToNomsNumber: String, val bookingId: String, val bookingStartDateTime: LocalDateTime) : AdditionalInformation
 
 data class PersonReference(val identifiers: List<Identifier>)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingMovedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingMovedEventHandler.kt
@@ -20,15 +20,14 @@ class PrisonerBookingMovedEventHandler(
   override fun handle(event: PrisonerBookingMovedEvent) {
     val movedToNomsNumber = event.movedToNomsNumber()
     val movedFromNomsNumber = event.movedFromNomsNumber()
-    val bookingId = event.bookingId()
-    val startDateTime = event.startDateTime()
+    val bookingId = event.bookingId().toLong()
+    val startDateTime = event.bookingStartDateTime()
 
-    log.info("handling booking moved from $movedFromNomsNumber to $movedToNomsNumber")
-    // update prisoner booking if exists
+    log.info("Handling booking move from [$movedFromNomsNumber] to [$movedToNomsNumber] for booking [$bookingId]")
+
     officialVisitRepository.countOVByPrisonerNumberAndBookingId(movedFromNomsNumber, bookingId, startDateTime).takeIf { it > 0 }?.let {
       officialVisitRepository.bookingMove(movedFromNomsNumber, movedToNomsNumber, bookingId, startDateTime)
-      prisonerVisitedRepository.replacePrisonerNumber(movedFromNomsNumber, movedToNomsNumber)
+      prisonerVisitedRepository.replacePrisonerNumberForBooking(movedFromNomsNumber, movedToNomsNumber, bookingId, startDateTime)
     }
-    log.info("PRISONER BOOKING MOVED EVENT:  Prisoner booking moved from $movedFromNomsNumber to $movedToNomsNumber ")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingMovedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingMovedEventHandlerTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
@@ -11,30 +12,42 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.han
 import java.time.LocalDateTime
 
 class PrisonerBookingMovedEventHandlerTest {
-  private val movedBookingEvent = PrisonerBookingMovedEvent(
-    BookingMovedInformation("ABC222", "ABC111", 1L, LocalDateTime.now()),
-  )
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val prisonerVisitedRepository: PrisonerVisitedRepository = mock()
 
   private val handler = PrisonerBookingMovedEventHandler(officialVisitRepository, prisonerVisitedRepository)
 
   @Test
-  fun `should move old prisoner booking with new prisoner`() {
-    val starTime = LocalDateTime.now()
-    val mergeBooking = PrisonerBookingMovedEvent(
-      BookingMovedInformation("ABC222", "ABC111", 1L, starTime),
+  fun `should update visits and prisoner visited for a booking move event`() {
+    val bookingStartDateTime = LocalDateTime.now()
+
+    val bookingMoveEvent = PrisonerBookingMovedEvent(
+      BookingMovedInformation("ABC222", "ABC111", "1", bookingStartDateTime),
     )
-    whenever(officialVisitRepository.countOVByPrisonerNumberAndBookingId("ABC222", 1L, starTime)).thenReturn(2)
-    handler.handle(mergeBooking)
-    verify(officialVisitRepository).bookingMove("ABC222", "ABC111", 1L, starTime)
-    verify(prisonerVisitedRepository).replacePrisonerNumber("ABC222", "ABC111")
+
+    whenever(officialVisitRepository.countOVByPrisonerNumberAndBookingId("ABC222", 1L, bookingStartDateTime)).thenReturn(2)
+
+    handler.handle(bookingMoveEvent)
+
+    verify(officialVisitRepository).bookingMove("ABC222", "ABC111", 1L, bookingStartDateTime)
+    verify(prisonerVisitedRepository).replacePrisonerNumberForBooking("ABC222", "ABC111", 1L, bookingStartDateTime)
   }
 
   @Test
-  fun `should not move if there are no matching prisoner booking found `() {
-    whenever(officialVisitRepository.countOVByPrisonerNumberAndBookingId("ABC222", 1L, LocalDateTime.now())).thenReturn(0)
-    handler.handle(movedBookingEvent)
+  fun `should not try to update visits when the count for prisoner number and booking ID is zero`() {
+    val bookingStartDateTime = LocalDateTime.now()
+
+    val bookingMoveEvent = PrisonerBookingMovedEvent(
+      BookingMovedInformation("ABC222", "ABC111", "1", bookingStartDateTime),
+    )
+
+    whenever(officialVisitRepository.countOVByPrisonerNumberAndBookingId("ABC222", 1L, bookingStartDateTime)).thenReturn(0)
+
+    handler.handle(bookingMoveEvent)
+
+    verify(officialVisitRepository).countOVByPrisonerNumberAndBookingId("ABC222", 1L, bookingStartDateTime)
+
+    verifyNoMoreInteractions(officialVisitRepository)
     verifyNoInteractions(prisonerVisitedRepository)
   }
 }


### PR DESCRIPTION
Couple of issues with this one.
* Event contained `bookingStartDateTime` not `startDateTime`
* The update of prisoner visited rows was not limited by bookingId or startDateTime.

These fixed and tests updated.
Not many tests here.. 