### PR TITLE
OV-544: Address slow query on prisoner visits repair endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/AuditedEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/AuditedEventRepository.kt
@@ -15,6 +15,6 @@ interface AuditedEventRepository : JpaRepository<AuditedEventEntity, Long> {
     WHERE ae.prisonerNumber = :prisonerNumber
     """,
   )
-  @Modifying(clearAutomatically = true)
+  @Modifying
   fun deleteAllByPrisonerNumber(prisonerNumber: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
@@ -105,7 +105,7 @@ interface OfficialVisitRepository : JpaRepository<OfficialVisitEntity, Long> {
       WHERE ov.prisonerNumber = :prisonerNumber
     """,
   )
-  @Modifying(clearAutomatically = true)
+  @Modifying()
   fun deleteAllByPrisonerNumber(prisonerNumber: String)
 
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitorRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitorRepository.kt
@@ -29,8 +29,8 @@ interface OfficialVisitorRepository : JpaRepository<OfficialVisitorEntity, Long>
   @Query(
     value = """
     DELETE FROM OfficialVisitorEntity ove
-    WHERE ove.officialVisitorId in (
-      SELECT ov.officialVisitId from OfficialVisitEntity ov where ov.prisonerNumber = :prisonerNumber
+    WHERE ove.officialVisit in (
+      SELECT ov from OfficialVisitEntity ov where ov.prisonerNumber = :prisonerNumber
     )
     """,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitorRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitorRepository.kt
@@ -29,9 +29,11 @@ interface OfficialVisitorRepository : JpaRepository<OfficialVisitorEntity, Long>
   @Query(
     value = """
     DELETE FROM OfficialVisitorEntity ove
-    WHERE ove.officialVisit.prisonerNumber = :prisonerNumber
+    WHERE ove.officialVisitorId in (
+      SELECT ov.officialVisitId from OfficialVisitEntity ov where ov.prisonerNumber = :prisonerNumber
+    )
     """,
   )
-  @Modifying(clearAutomatically = true)
+  @Modifying
   fun deleteAllByPrisonerNumber(prisonerNumber: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/PrisonerVisitedRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/PrisonerVisitedRepository.kt
@@ -54,7 +54,7 @@ interface PrisonerVisitedRepository : JpaRepository<PrisonerVisitedEntity, Long>
     WHERE pv.prisonerNumber = :prisonerNumber
     """,
   )
-  @Modifying(clearAutomatically = true)
+  @Modifying
   fun deleteAllByPrisonerNumber(prisonerNumber: String)
 
   fun countByPrisonerNumber(prisonerNumber: String): Long

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/VisitorEquipmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/VisitorEquipmentRepository.kt
@@ -14,9 +14,17 @@ interface VisitorEquipmentRepository : JpaRepository<VisitorEquipmentEntity, Lon
   @Query(
     value = """
     DELETE FROM VisitorEquipmentEntity ve
-    WHERE ve.officialVisitor.officialVisit.prisonerNumber = :prisonerNumber
+    WHERE ve.officialVisitor IN (
+      SELECT ove
+      FROM OfficialVisitorEntity ove
+      WHERE ove.officialVisit IN (
+        SELECT ov
+        FROM OfficialVisitEntity ov
+        where ov.prisonerNumber = :prisonerNumber
+      )
+    )
     """,
   )
-  @Modifying(clearAutomatically = true)
+  @Modifying
   fun deleteAllByPrisonerNumber(prisonerNumber: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/RepairPrisonerVisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/RepairPrisonerVisitsService.kt
@@ -69,18 +69,23 @@ class RepairPrisonerVisitsService(
 
     // Delete the prisonerVisited entities (Child entity of a visit)
     prisonerVisitedRepository.deleteAllByPrisonerNumber(prisonerNumber)
+    prisonerVisitedRepository.flush()
 
     // Delete the visitor equipment (child entity of a visitor)
     visitorEquipmentRepository.deleteAllByPrisonerNumber(prisonerNumber)
+    visitorEquipmentRepository.flush()
 
     // Delete the visitors on these visits (child entity of a visit)
     officialVisitorRepository.deleteAllByPrisonerNumber(prisonerNumber)
+    officialVisitorRepository.flush()
 
     // Delete the visits for this prisoner (it's a bulk operation and JPA cascades are not honored here)
     officialVisitRepository.deleteAllByPrisonerNumber(prisonerNumber)
+    officialVisitRepository.flush()
 
     // Delete the audited events for the visits
     auditedEventRepository.deleteAllByPrisonerNumber(prisonerNumber)
+    auditedEventRepository.flush()
 
     return countPrisonerVisited
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/RepairPrisonerVisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/RepairPrisonerVisitsService.kt
@@ -79,7 +79,7 @@ class RepairPrisonerVisitsService(
     // Delete the visits for this prisoner (it's a bulk operation and JPA cascades are not honored here)
     officialVisitRepository.deleteAllByPrisonerNumber(prisonerNumber)
 
-    // Delete the audited events for the visitss
+    // Delete the audited events for the visits
     auditedEventRepository.deleteAllByPrisonerNumber(prisonerNumber)
 
     return countPrisonerVisited

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.AuditedEventRep
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitorRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.VisitorEquipmentRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
@@ -68,6 +69,9 @@ abstract class IntegrationTestBase {
   protected lateinit var prisonerVisitedRepository: PrisonerVisitedRepository
 
   @Autowired
+  protected lateinit var visitorEquipmentRepository: VisitorEquipmentRepository
+
+  @Autowired
   protected lateinit var auditedEventRepository: AuditedEventRepository
 
   @BeforeEach
@@ -99,6 +103,7 @@ abstract class IntegrationTestBase {
   protected fun clearAllVisitData() {
     auditedEventRepository.deleteAll()
     prisonerVisitedRepository.deleteAll()
+    visitorEquipmentRepository.deleteAll()
     officialVisitorRepository.deleteAll()
     officialVisitRepository.deleteAll()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/RepairPrisonerVisitsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/RepairPrisonerVisitsIntegrationTest.kt
@@ -61,7 +61,6 @@ class RepairPrisonerVisitsIntegrationTest : IntegrationTestBase() {
   private val nextMondayAt9 = createOfficialVisitRequest(Moorland.MONDAY_9_TO_10_VISIT_SLOT, listOf(officialVisitor))
 
   @BeforeEach
-  @Transactional
   fun initialiseData() {
     clearAllVisitData()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/RepairPrisonerVisitsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/RepairPrisonerVisitsIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.test.web.reactive.server.expectBodyList
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.CONTACT_MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
@@ -44,7 +43,6 @@ import java.time.LocalTime
 import java.util.UUID
 
 class RepairPrisonerVisitsIntegrationTest : IntegrationTestBase() {
-
   private final val visitDateInTheFuture = today().next(DayOfWeek.MONDAY)
 
   private val officialVisitor = OfficialVisitor(
@@ -88,7 +86,6 @@ class RepairPrisonerVisitsIntegrationTest : IntegrationTestBase() {
   }
 
   @AfterEach
-  @Transactional
   fun tearDown() {
     clearAllVisitData()
   }


### PR DESCRIPTION
Addresses a couple of issues:

* JPQL - obscure queries were generated in the previous iterations - they worked, but were slow.
* Running locally with integration tests I can see the queries generated are much clearer, and will be more efficient.
* New versions use sub-selects to specifically identify the component parts of visits related to a prisoner.
* The @Modifying(clearAutomatically=true) was unnecessary, and introduced an overhead into this endpoint. 