### PR TITLE
OV-546: Reworking the prisoner.received event for keeping the current term marker aligned.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
@@ -108,14 +108,7 @@ interface OfficialVisitRepository : JpaRepository<OfficialVisitEntity, Long> {
   @Modifying()
   fun deleteAllByPrisonerNumber(prisonerNumber: String)
 
-  @Query(
-    value = """
-      SELECT ov
-      FROM OfficialVisitEntity ov
-      WHERE ov.prisonerNumber = :prisonerNumber 
-      AND ov.currentTerm = true
-      AND ov.offenderBookId != :currentBookingId
-    """,
-  )
-  fun findAllCurrentTermVisitsForPrisoner(prisonerNumber: String, currentBookingId: Long): List<OfficialVisitEntity>
+  fun findAllByPrisonerNumberAndOffenderBookId(prisonerNumber: String, bookingId: Long): List<OfficialVisitEntity>
+
+  fun findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber: String, bookingId: Long): List<OfficialVisitEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingService.kt
@@ -36,7 +36,7 @@ fun auditVisitCancellationEvent(initializer: CancelVisitDsl.() -> Unit): AuditEv
 
 fun auditVisitCompletionEvent(initializer: CompleteVisitDsl.() -> Unit): AuditEventDto = CompleteVisitDsl().apply(initializer).toAuditEvent()
 
-fun auditVisitSetToPreviousTermEvent(initializer: NewBookingVisitDsl.() -> Unit): AuditEventDto = NewBookingVisitDsl().apply(initializer).toAuditEvent()
+fun auditVisitCurrentTermEvent(initializer: NewBookingVisitDsl.() -> Unit): AuditEventDto = NewBookingVisitDsl().apply(initializer).toAuditEvent()
 
 @DslMarker
 annotation class AuditEventDslMarker
@@ -147,7 +147,7 @@ class CompleteVisitDsl : AuditEventDsl() {
 }
 
 class NewBookingVisitDsl : AuditEventDsl() {
-  override fun detailsText(): String = "A new booking for the prisoner has changed this visit so it relates to a previous term in prison"
+  override fun detailsText(): String = "A new booking for the prisoner has changed the current term"
 }
 
 data class AuditEventDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerReceivedEventHandler.kt
@@ -5,13 +5,12 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitStatusType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitSetToPreviousTermEvent
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCurrentTermEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.PrisonerReceivedEvent
-import java.time.LocalDate
 import kotlin.String
 
 @Component
@@ -43,38 +42,43 @@ class PrisonerReceivedEventHandler(
   }
 
   /**
-   * This method finds all visits for a prisoner number where the currentTerm == true and the bookingId on the
-   * visit is different from the current bookingId. This avoids changing any visits for the currently active booking.
+   * This method:
+   *  - finds visits for the prisoner where the bookingId == the new booking, and sets currentTerm = true if it is false.
+   *  - finds visits for the prisoner where the bookingId != the new booking, and sets currentTerm = false if it is true.
    *
-   * It then updates these visits to set the currentTerm = false to indicate that they are now related to a previous
-   * term in prison. No sync events are required for this operation as it is only reacting to the creation of a
-   * new booking, not to any changes in visits or visitors.
+   * No sync events are required for this operation as these changes have already been applied in NOMIS.
    */
   private fun processNewBooking(prisonerNumber: String, bookingId: Long) {
-    val visitsToUpdate = officialVisitRepository.findAllCurrentTermVisitsForPrisoner(prisonerNumber, bookingId)
+    var currentTermCounter = 0
+    var previousTermCounter = 0
 
-    log.info("PRISONER RECEIVED EVENT: Found [${visitsToUpdate.size} visits to update for [$prisonerNumber]")
-
-    visitsToUpdate.forEach { visit ->
-      // Check whether this visit is in the future and SCHEDULED - if so log message.
-      if (visit.visitStatusCode == VisitStatusType.SCHEDULED && visit.visitDate > LocalDate.now()) {
-        log.info("PRISONER RECEIVED EVENT: OfficialVisitId [${visit.officialVisitId}] at [${visit.prisonCode}] for [$prisonerNumber] is still SCHEDULED [${visit.visitDate} but will be set to currentTerm = false")
+    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber, bookingId).forEach { visit ->
+      if (!visit.currentTerm) {
+        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = true })
+        auditCurrentTermChange(visit)
+        currentTermCounter++
       }
-
-      // Update the currentTerm to false
-      officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
-
-      // Create an audit event for the visit to record that it is no longer related to the current term in prison
-      auditingService.recordAuditEvent(
-        auditVisitSetToPreviousTermEvent {
-          officialVisitId(visit.officialVisitId)
-          summaryText("The visit is no longer related to the current term in prison")
-          eventSource("NOMIS")
-          user(UserService.getServiceAsUser())
-          prisonCode(visit.prisonCode)
-          prisonerNumber(prisonerNumber)
-        },
-      )
     }
+
+    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber, bookingId).forEach { visit ->
+      if (visit.currentTerm) {
+        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
+        auditCurrentTermChange(visit)
+        previousTermCounter++
+      }
+    }
+
+    log.info("PRISONER RECEIVED EVENT: [$currentTermCounter] visits set to currentTerm = true, [$previousTermCounter] set to currentTerm = false")
   }
+
+  private fun auditCurrentTermChange(visit: OfficialVisitEntity) = auditingService.recordAuditEvent(
+    auditVisitCurrentTermEvent {
+      officialVisitId(visit.officialVisitId)
+      summaryText("The visit current term marker has been updated")
+      eventSource("NOMIS")
+      user(UserService.getServiceAsUser())
+      prisonCode(visit.prisonCode)
+      prisonerNumber(visit.prisonerNumber)
+    },
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerReceivedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerReceivedEventHandlerTest.kt
@@ -62,81 +62,154 @@ class PrisonerReceivedEventHandlerTest {
       prisonerSearchPrisoner(
         prisonerNumber = PENTONVILLE_PRISONER.number,
         prisonCode = PENTONVILLE_PRISONER.prison,
-        bookingId = PENTONVILLE_PRISONER.bookingId,
+        bookingId = PENTONVILLE_PRISONER.bookingId, // BookingId = 1L
       ),
     )
 
     whenever(
-      officialVisitRepository.findAllCurrentTermVisitsForPrisoner(
+      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(
         prisonerNumber = PENTONVILLE_PRISONER.number,
-        currentBookingId = 1L,
+        bookingId = 1L,
       ),
     ).thenReturn(
       listOf(
-        createAVisitEntity(1L),
-        createAVisitEntity(2L),
+        createAVisitEntity(1L).apply {
+          offenderBookId = 1L
+          currentTerm = false
+        },
+        createAVisitEntity(2L).apply {
+          offenderBookId = 1L
+          currentTerm = true
+        },
+      ),
+    )
+
+    whenever(
+      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(
+        prisonerNumber = PENTONVILLE_PRISONER.number,
+        bookingId = 1L,
+      ),
+    ).thenReturn(
+      listOf(
+        createAVisitEntity(3L).apply {
+          offenderBookId = 2L
+          currentTerm = true
+        },
       ),
     )
   }
 
+  /**
+   * This test should update bookingIds 1 and 3, but leave 2 unchanged, as its current term
+   * marker is already correct for the circumstances.
+   */
   @Test
-  fun `should set the currentTerm marker to false on visits for a NEW_ADMISSION event`() {
+  fun `should manage the currentTerm markers on visits for a NEW_ADMISSION event`() {
     handler.handle(newBookingEvent)
 
     verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
 
-    verify(officialVisitRepository).findAllCurrentTermVisitsForPrisoner(
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(
       prisonerNumber = PENTONVILLE_PRISONER.number,
-      currentBookingId = 1L,
+      bookingId = 1L,
+    )
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
     )
 
     val visitCaptor = argumentCaptor<OfficialVisitEntity>()
+
     verify(officialVisitRepository, times(2)).saveAndFlush(visitCaptor.capture())
+
     with(visitCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(prisonCode).isEqualTo(PENTONVILLE)
+      assertThat(currentTerm).isEqualTo(true)
+    }
+
+    with(visitCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
       assertThat(currentTerm).isEqualTo(false)
     }
 
     val auditEventCaptor = argumentCaptor<AuditEventDto>()
+
     verify(auditingService, times(2)).recordAuditEvent(auditEventCaptor.capture())
+
     with(auditEventCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit is no longer related to the current term in prison")
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
+    }
+
+    with(auditEventCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(prisonCode).isEqualTo(PENTONVILLE)
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
     }
   }
 
+  /**
+   * This test should update bookingIds 1 and 3, but leave 2 unchanged, as its current term
+   * marker is already correct for the circumstances.
+   */
   @Test
-  fun `should set the currentTerm marker to false on visits for a READMISSION_SWITCH_BOOKING event`() {
+  fun `should manage the currentTerm markers on visits for a READMISSION_SWITCH_BOOKING event`() {
     handler.handle(newSwitchBookingEvent)
 
     verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
 
-    verify(officialVisitRepository).findAllCurrentTermVisitsForPrisoner(
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(
       prisonerNumber = PENTONVILLE_PRISONER.number,
-      currentBookingId = 1L,
+      bookingId = 1L,
+    )
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
     )
 
     val visitCaptor = argumentCaptor<OfficialVisitEntity>()
+
     verify(officialVisitRepository, times(2)).saveAndFlush(visitCaptor.capture())
+
     with(visitCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(prisonCode).isEqualTo(PENTONVILLE)
+      assertThat(currentTerm).isEqualTo(true)
+    }
+
+    with(visitCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
       assertThat(currentTerm).isEqualTo(false)
     }
 
     val auditEventCaptor = argumentCaptor<AuditEventDto>()
+
     verify(auditingService, times(2)).recordAuditEvent(auditEventCaptor.capture())
+
     with(auditEventCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit is no longer related to the current term in prison")
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
     }
+
     with(auditEventCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit is no longer related to the current term in prison")
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
     }
   }
 


### PR DESCRIPTION
This change corrects an issue found in reconciliation where the currentTerm markers were drifting.
Syscon identified the prisoner.received event was causing this. 
It previously was a only updating the visits with a different booking ID to false, and never updating the visits with the SAME booking id to true.