### PR TITLE
OV-555: Prisoner merge checking and setting the currentTerm marker for affected visits.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
@@ -59,9 +59,15 @@ interface OfficialVisitRepository : JpaRepository<OfficialVisitEntity, Long> {
     createdTime: LocalDateTime,
   ): List<OfficialVisitEntity>
 
-  @Query(value = "UPDATE OfficialVisitEntity ov SET ov.prisonerNumber = :replacementNumber, ov.offenderBookId = :bookingId WHERE ov.prisonerNumber = :removedNumber")
+  @Query(
+    value = """
+      UPDATE OfficialVisitEntity ov 
+      SET ov.prisonerNumber = :replacementNumber
+      WHERE ov.prisonerNumber = :removedNumber
+    """,
+  )
   @Modifying
-  fun mergePrisonerNumber(removedNumber: String, replacementNumber: String, bookingId: Long?)
+  fun mergePrisonerNumber(removedNumber: String, replacementNumber: String)
 
   @Query(
     value = """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
@@ -5,11 +5,13 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitChangeEvent
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCurrentTermEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.PrisonerMergedEvent
 
 @Component
@@ -28,36 +30,62 @@ class PrisonerMergedEventHandler(
     val removedPrisonerNumber = event.removedPrisonerNumber()
     val newPrisonerNumber = event.replacementPrisonerNumber()
 
-    // Get new prisoner details
     val prisoner = prisonerSearchClient.getPrisoner(newPrisonerNumber)
       ?: throw EntityNotFoundException("Prisoner not found $newPrisonerNumber")
 
-    log.info("Booking Id for prisoner $newPrisonerNumber is $prisoner.bookingId?.toLong()")
+    log.info("Prisoner merge from $removedPrisonerNumber to $newPrisonerNumber (on bookingId ${prisoner.bookingId?.toLong()})")
 
-    // get all affected visits before bulk update so each update is auditable by visit id
     val affectedVisits = officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)
 
     affectedVisits.takeIf { it.isNotEmpty() }?.let {
-      officialVisitRepository.mergePrisonerNumber(removedPrisonerNumber, newPrisonerNumber, prisoner.bookingId?.toLong())
+      officialVisitRepository.mergePrisonerNumber(removedPrisonerNumber, newPrisonerNumber)
       prisonerVisitedRepository.replacePrisonerNumber(removedPrisonerNumber, newPrisonerNumber)
 
       affectedVisits.forEach { visit ->
         auditingService.recordAuditEvent(
           auditVisitChangeEvent {
             officialVisitId(visit.officialVisitId)
-            summaryText("Official visit updated due to prisoner merge")
+            summaryText("Official visit updated by prisoner merge")
             eventSource("NOMIS")
             user(UserService.getClientAsUser("NOMIS"))
             prisonCode(visit.prisonCode)
             prisonerNumber(newPrisonerNumber)
             changes {
               change("Prisoner number", removedPrisonerNumber, newPrisonerNumber)
-              change("Offender book ID", visit.offenderBookId, prisoner.bookingId?.toLong())
             }
           },
         )
       }
+
+      // Check and correct the current term markers for this prisoner's bookings
+      processCurrentTermMarkers(newPrisonerNumber, prisoner.bookingId!!.toLong())
     }
-    log.info("PRISONER MERGED EVENT: Removed '$removedPrisonerNumber' replaced with '$newPrisonerNumber' ")
   }
+
+  private fun processCurrentTermMarkers(prisonerNumber: String, bookingId: Long) {
+    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber, bookingId).forEach { visit ->
+      if (!visit.currentTerm) {
+        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = true })
+        auditCurrentTermChange(visit)
+      }
+    }
+
+    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber, bookingId).forEach { visit ->
+      if (visit.currentTerm) {
+        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
+        auditCurrentTermChange(visit)
+      }
+    }
+  }
+
+  private fun auditCurrentTermChange(visit: OfficialVisitEntity) = auditingService.recordAuditEvent(
+    auditVisitCurrentTermEvent {
+      officialVisitId(visit.officialVisitId)
+      summaryText("The visit current term marker has been updated by a merge")
+      eventSource("NOMIS")
+      user(UserService.getServiceAsUser())
+      prisonCode(visit.prisonCode)
+      prisonerNumber(visit.prisonerNumber)
+    },
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerReceivedEventHandler.kt
@@ -74,7 +74,7 @@ class PrisonerReceivedEventHandler(
   private fun auditCurrentTermChange(visit: OfficialVisitEntity) = auditingService.recordAuditEvent(
     auditVisitCurrentTermEvent {
       officialVisitId(visit.officialVisitId)
-      summaryText("The visit current term marker has been updated")
+      summaryText("The visit current term marker has been updated due to a new booking")
       eventSource("NOMIS")
       user(UserService.getServiceAsUser())
       prisonCode(visit.prisonCode)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
@@ -20,7 +21,11 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingS
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerMergedEventHandler
 
 class PrisonerMergedEventHandlerTest {
-  private val mergeEvent = PrisonerMergedEvent(MergeInformation("ABC222", "ABC111"))
+  private val removedPrisonerNumber = "A1234AA"
+  private val retainedPrisonerNumber = "A1234BB"
+  private val mergeEvent = PrisonerMergedEvent(
+    additionalInformation = MergeInformation(nomsNumber = retainedPrisonerNumber, removedPrisonerNumber),
+  )
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val prisonerVisitedRepository: PrisonerVisitedRepository = mock()
   private val prisonerSearchClient: PrisonerSearchClient = mock()
@@ -30,28 +35,103 @@ class PrisonerMergedEventHandlerTest {
 
   @Test
   fun `should merge old prisoner with new prisoner`() {
-    whenever(prisonerSearchClient.getPrisoner("ABC222")) doReturn prisonerSearchPrisoner(prisonerNumber = MOORLAND_PRISONER.number, prisonCode = MOORLAND_PRISONER.prison, bookingId = MOORLAND_PRISONER.bookingId)
-    whenever(officialVisitRepository.findAllByPrisonerNumber("ABC111")).thenReturn(listOf(createAVisitEntity(1L), createAVisitEntity(2L)))
+    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)) doReturn prisonerSearchPrisoner(
+      prisonerNumber = retainedPrisonerNumber,
+      prisonCode = MOORLAND_PRISONER.prison,
+      bookingId = MOORLAND_PRISONER.bookingId,
+    )
+
+    whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(
+      listOf(
+        createAVisitEntity(1L),
+        createAVisitEntity(2L),
+      ),
+    )
+
+    // No current term markers to update
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)).thenReturn(emptyList())
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)).thenReturn(emptyList())
+
     handler.handle(mergeEvent)
-    verify(officialVisitRepository).mergePrisonerNumber("ABC111", "ABC222", 1L)
-    verify(prisonerVisitedRepository).replacePrisonerNumber("ABC111", "ABC222")
+
+    // Do the prisoner updates - once each
+    verify(officialVisitRepository).mergePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
+    verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
+
+    // Check the current term markers - once each
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
+
+    // Record updates on 2 visits
     verify(auditingService, times(2)).recordAuditEvent(any())
   }
 
   @Test
-  fun `should not merge old prisoner with new prisoner if no official visits exists for old prisoner`() {
-    whenever(prisonerSearchClient.getPrisoner("ABC222")) doReturn prisonerSearchPrisoner(prisonerNumber = MOORLAND_PRISONER.number, prisonCode = MOORLAND_PRISONER.prison, bookingId = MOORLAND_PRISONER.bookingId)
-    whenever(officialVisitRepository.findAllByPrisonerNumber("ABC111")).thenReturn(emptyList())
+  fun `should merge and update current term marker on an existing visit`() {
+    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)) doReturn prisonerSearchPrisoner(
+      prisonerNumber = retainedPrisonerNumber,
+      prisonCode = MOORLAND_PRISONER.prison,
+      bookingId = MOORLAND_PRISONER.bookingId,
+    )
+
+    // One visit to update
+    whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(
+      listOf(createAVisitEntity(1L)),
+    )
+
+    // One current term marker to update to true
+    whenever(
+      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(
+        retainedPrisonerNumber,
+        MOORLAND_PRISONER.bookingId,
+      ),
+    ).thenReturn(listOf(createAVisitEntity(2L).apply { currentTerm = false }))
+
+    // One current term marker to update to false
+    whenever(
+      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(
+        retainedPrisonerNumber,
+        MOORLAND_PRISONER.bookingId,
+      ),
+    ).thenReturn(listOf(createAVisitEntity(3L).apply { currentTerm = true }))
+
     handler.handle(mergeEvent)
+
+    // Called once each
+    verify(officialVisitRepository).mergePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
+    verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
+
+    // Called once each
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
+
+    // Called 3 times - once for the visit update, twice for current term updates
+    verify(auditingService, times(3)).recordAuditEvent(any())
+  }
+
+  @Test
+  fun `should not not call merge if no official visits exist for the removed prisoner number`() {
+    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)) doReturn prisonerSearchPrisoner(
+      prisonerNumber = MOORLAND_PRISONER.number,
+      prisonCode = MOORLAND_PRISONER.prison,
+      bookingId = MOORLAND_PRISONER.bookingId,
+    )
+
+    whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(emptyList())
+
+    handler.handle(mergeEvent)
+
+    verify(officialVisitRepository).findAllByPrisonerNumber(removedPrisonerNumber)
+    verifyNoMoreInteractions(officialVisitRepository)
     verifyNoInteractions(prisonerVisitedRepository, auditingService)
   }
 
   @Test
   fun `should throw exception if invalid prisoner passed`() {
-    whenever(prisonerSearchClient.getPrisoner("ABC222")).thenThrow(EntityNotFoundException("Prisoner not found ABC222"))
+    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)).thenThrow(EntityNotFoundException("Prisoner not found $retainedPrisonerNumber"))
     assertThrows<EntityNotFoundException> {
       handler.handle(mergeEvent)
     }
-    verifyNoInteractions(prisonerVisitedRepository, officialVisitRepository)
+    verifyNoInteractions(prisonerVisitedRepository, officialVisitRepository, auditingService)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerReceivedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerReceivedEventHandlerTest.kt
@@ -145,14 +145,14 @@ class PrisonerReceivedEventHandlerTest {
       assertThat(officialVisitId).isEqualTo(1L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
     }
 
     with(auditEventCaptor.secondValue) {
       assertThat(officialVisitId).isEqualTo(3L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
     }
   }
 
@@ -202,14 +202,14 @@ class PrisonerReceivedEventHandlerTest {
       assertThat(officialVisitId).isEqualTo(1L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
     }
 
     with(auditEventCaptor.secondValue) {
       assertThat(officialVisitId).isEqualTo(3L)
       assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
       assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated")
+      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
     }
   }
 


### PR DESCRIPTION
This makes use of the `offenderBookId` to determine which visits are current term, and which are not, to stay aligned with NOMIS. 