### PR TITLE
OV-565: Avoiding race condition for prisoner merge

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
@@ -56,9 +56,10 @@ data class ReleaseInformation(val nomsNumber: String, val reason: String, val pr
 class PrisonerMergedEvent(additionalInformation: MergeInformation) : DomainEvent<MergeInformation>(DomainEventType.PRISONER_MERGED, additionalInformation) {
   fun replacementPrisonerNumber() = additionalInformation.nomsNumber
   fun removedPrisonerNumber() = additionalInformation.removedNomsNumber
+  fun bookingId() = additionalInformation.bookingId
 }
 
-data class MergeInformation(val nomsNumber: String, val removedNomsNumber: String) : AdditionalInformation
+data class MergeInformation(val nomsNumber: String, val removedNomsNumber: String, val bookingId: String) : AdditionalInformation
 
 class PrisonerBookingMovedEvent(additionalInformation: BookingMovedInformation) : DomainEvent<BookingMovedInformation>(DomainEventType.PRISONER_BOOKING_MOVED, additionalInformation) {
   @JsonIgnore

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers
 
-import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
@@ -18,7 +16,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.Pri
 class PrisonerMergedEventHandler(
   private val officialVisitRepository: OfficialVisitRepository,
   private val prisonerVisitedRepository: PrisonerVisitedRepository,
-  private val prisonerSearchClient: PrisonerSearchClient,
   private val auditingService: AuditingService,
 ) : DomainEventHandler<PrisonerMergedEvent> {
   companion object {
@@ -29,11 +26,9 @@ class PrisonerMergedEventHandler(
   override fun handle(event: PrisonerMergedEvent) {
     val removedPrisonerNumber = event.removedPrisonerNumber()
     val newPrisonerNumber = event.replacementPrisonerNumber()
+    val bookingId = event.bookingId()
 
-    val prisoner = prisonerSearchClient.getPrisoner(newPrisonerNumber)
-      ?: throw EntityNotFoundException("Prisoner not found $newPrisonerNumber")
-
-    log.info("Prisoner merge from $removedPrisonerNumber to $newPrisonerNumber (on bookingId ${prisoner.bookingId?.toLong()})")
+    log.info("Prisoner merge from $removedPrisonerNumber to $newPrisonerNumber (current bookingId ${bookingId.toLong()})")
 
     val affectedVisits = officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)
 
@@ -58,7 +53,7 @@ class PrisonerMergedEventHandler(
       }
 
       // Check and correct the current term markers for this prisoner's bookings
-      processCurrentTermMarkers(newPrisonerNumber, prisoner.bookingId!!.toLong())
+      processCurrentTermMarkers(newPrisonerNumber, bookingId.toLong())
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsListenerTest.kt
@@ -59,7 +59,7 @@ class InboundEventsListenerTest {
   @Test
   fun `should delegate prisoner merged domain event to service`() {
     val event = PrisonerMergedEvent(
-      MergeInformation(nomsNumber = "A1111AA", removedNomsNumber = "B1111BB"),
+      MergeInformation(nomsNumber = "A1111AA", removedNomsNumber = "B1111BB", bookingId = "1"),
     )
     val message = message(event)
     val rawMessage = mapper.writeValueAsString(message)
@@ -71,6 +71,7 @@ class InboundEventsListenerTest {
         it isInstanceOf PrisonerMergedEvent::class.java
         (it as PrisonerMergedEvent).additionalInformation.nomsNumber isEqualTo "A1111AA"
         it.additionalInformation.removedNomsNumber isEqualTo "B1111BB"
+        it.additionalInformation.bookingId isEqualTo "1"
       },
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsServiceTest.kt
@@ -35,7 +35,7 @@ class InboundEventsServiceTest {
 
   @Test
   fun `should call prisoner merged handler when for prisoner merged event`() {
-    val event = PrisonerMergedEvent(MergeInformation(nomsNumber = "A1111AA", removedNomsNumber = "B1111BB"))
+    val event = PrisonerMergedEvent(MergeInformation(nomsNumber = "A1111AA", removedNomsNumber = "B1111BB", bookingId = "1"))
     service.process(event)
     verify(prisonerMergedEventHandler).handle(event)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
@@ -1,20 +1,15 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound
 
-import jakarta.persistence.EntityNotFoundException
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
@@ -24,23 +19,20 @@ class PrisonerMergedEventHandlerTest {
   private val removedPrisonerNumber = "A1234AA"
   private val retainedPrisonerNumber = "A1234BB"
   private val mergeEvent = PrisonerMergedEvent(
-    additionalInformation = MergeInformation(nomsNumber = retainedPrisonerNumber, removedPrisonerNumber),
+    additionalInformation = MergeInformation(
+      nomsNumber = retainedPrisonerNumber,
+      removedNomsNumber = removedPrisonerNumber,
+      bookingId = "1",
+    ),
   )
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val prisonerVisitedRepository: PrisonerVisitedRepository = mock()
-  private val prisonerSearchClient: PrisonerSearchClient = mock()
   private val auditingService: AuditingService = mock()
 
-  private val handler = PrisonerMergedEventHandler(officialVisitRepository, prisonerVisitedRepository, prisonerSearchClient, auditingService)
+  private val handler = PrisonerMergedEventHandler(officialVisitRepository, prisonerVisitedRepository, auditingService)
 
   @Test
   fun `should merge old prisoner with new prisoner`() {
-    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)) doReturn prisonerSearchPrisoner(
-      prisonerNumber = retainedPrisonerNumber,
-      prisonCode = MOORLAND_PRISONER.prison,
-      bookingId = MOORLAND_PRISONER.bookingId,
-    )
-
     whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(
       listOf(
         createAVisitEntity(1L),
@@ -68,12 +60,6 @@ class PrisonerMergedEventHandlerTest {
 
   @Test
   fun `should merge and update current term marker on an existing visit`() {
-    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)) doReturn prisonerSearchPrisoner(
-      prisonerNumber = retainedPrisonerNumber,
-      prisonCode = MOORLAND_PRISONER.prison,
-      bookingId = MOORLAND_PRISONER.bookingId,
-    )
-
     // One visit to update
     whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(
       listOf(createAVisitEntity(1L)),
@@ -110,13 +96,7 @@ class PrisonerMergedEventHandlerTest {
   }
 
   @Test
-  fun `should not not call merge if no official visits exist for the removed prisoner number`() {
-    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)) doReturn prisonerSearchPrisoner(
-      prisonerNumber = MOORLAND_PRISONER.number,
-      prisonCode = MOORLAND_PRISONER.prison,
-      bookingId = MOORLAND_PRISONER.bookingId,
-    )
-
+  fun `should not call merge when no official visits exist for the removed prisoner number`() {
     whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(emptyList())
 
     handler.handle(mergeEvent)
@@ -124,14 +104,5 @@ class PrisonerMergedEventHandlerTest {
     verify(officialVisitRepository).findAllByPrisonerNumber(removedPrisonerNumber)
     verifyNoMoreInteractions(officialVisitRepository)
     verifyNoInteractions(prisonerVisitedRepository, auditingService)
-  }
-
-  @Test
-  fun `should throw exception if invalid prisoner passed`() {
-    whenever(prisonerSearchClient.getPrisoner(retainedPrisonerNumber)).thenThrow(EntityNotFoundException("Prisoner not found $retainedPrisonerNumber"))
-    assertThrows<EntityNotFoundException> {
-      handler.handle(mergeEvent)
-    }
-    verifyNoInteractions(prisonerVisitedRepository, officialVisitRepository, auditingService)
   }
 }


### PR DESCRIPTION
Using prisoner search client within a merge event handler introduces a race condition between prison-offender-events and prisoner-search, as they will both react to the same event, and it depends which gets there first. 

This can be avoided by using the `bookingId` provided within the event itself, which should always be the latest one from the `retainedPrisoner`.