### PR TITLE
OV-567: Merge update to avoid mixture of HQL and JPSQL

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
@@ -61,16 +61,6 @@ interface OfficialVisitRepository : JpaRepository<OfficialVisitEntity, Long> {
 
   @Query(
     value = """
-      UPDATE OfficialVisitEntity ov 
-      SET ov.prisonerNumber = :replacementNumber
-      WHERE ov.prisonerNumber = :removedNumber
-    """,
-  )
-  @Modifying
-  fun mergePrisonerNumber(removedNumber: String, replacementNumber: String)
-
-  @Query(
-    value = """
       UPDATE OfficialVisitEntity ov
       SET ov.prisonerNumber = :replacementNumber 
       WHERE ov.prisonerNumber = :removedNumber and ov.offenderBookId = :bookingId and ov.createdTime >= :startDateTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
@@ -33,10 +33,11 @@ class PrisonerMergedEventHandler(
     val affectedVisits = officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)
 
     affectedVisits.takeIf { it.isNotEmpty() }?.let {
-      officialVisitRepository.mergePrisonerNumber(removedPrisonerNumber, newPrisonerNumber)
       prisonerVisitedRepository.replacePrisonerNumber(removedPrisonerNumber, newPrisonerNumber)
 
       affectedVisits.forEach { visit ->
+        officialVisitRepository.saveAndFlush(visit.apply { prisonerNumber = newPrisonerNumber })
+
         auditingService.recordAuditEvent(
           auditVisitChangeEvent {
             officialVisitId(visit.officialVisitId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
@@ -46,8 +46,10 @@ class PrisonerMergedEventHandlerTest {
 
     handler.handle(mergeEvent)
 
-    // Do the prisoner updates - once each
-    verify(officialVisitRepository).mergePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
+    // Should be 2 visit updates
+    verify(officialVisitRepository, times(2)).saveAndFlush(any())
+
+    // One replacement of prisoner visited
     verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
 
     // Check the current term markers - once each
@@ -83,8 +85,10 @@ class PrisonerMergedEventHandlerTest {
 
     handler.handle(mergeEvent)
 
-    // Called once each
-    verify(officialVisitRepository).mergePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
+    // Should be 3 visits updated (one for the prisoner number, 2 for the current term markers)
+    verify(officialVisitRepository, times(3)).saveAndFlush(any())
+
+    // One call to prisoner visited
     verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
 
     // Called once each


### PR DESCRIPTION
This change avoids the overlapping updates for visits - which caused an issue on a merge from last night.