### PR TITLE
OV-567: Final (hopefully) merge adjustment.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
@@ -52,10 +52,10 @@ class PrisonerMergedEventHandler(
           },
         )
       }
-
-      // Check and correct the current term markers for this prisoner's bookings
-      processCurrentTermMarkers(newPrisonerNumber, bookingId.toLong())
     }
+
+    // Check and correct the current term markers for this prisoner's bookings - needs to be outside the empty check
+    processCurrentTermMarkers(newPrisonerNumber, bookingId.toLong())
   }
 
   private fun processCurrentTermMarkers(prisonerNumber: String, bookingId: Long) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
@@ -6,7 +6,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
@@ -106,7 +105,9 @@ class PrisonerMergedEventHandlerTest {
     handler.handle(mergeEvent)
 
     verify(officialVisitRepository).findAllByPrisonerNumber(removedPrisonerNumber)
-    verifyNoMoreInteractions(officialVisitRepository)
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
+
     verifyNoInteractions(prisonerVisitedRepository, auditingService)
   }
 }


### PR DESCRIPTION
It needs to adjust current term markers for old and new prisoner numbers, regardless of whether there were visits against the old number or not (there may have been old visits against the new number)