### PR TITLE
OV-576: Fix the sync issues when the call to manage-users-api times-out

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/sync/SyncFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/sync/SyncFacade.kt
@@ -10,8 +10,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync.SyncUpd
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync.SyncUpdateTimeSlotRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync.SyncUpdateVisitSlotRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sync.SyncOfficialVisitor
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.OutboundEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.OutboundEventsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
@@ -45,7 +43,6 @@ class SyncFacade(
   val syncOfficialVisitService: SyncOfficialVisitService,
   val syncOfficialVisitorService: SyncOfficialVisitorService,
   val outboundEventsService: OutboundEventsService,
-  val userService: UserService,
 ) {
 
   // ---------------  Time slots ----------------------
@@ -59,7 +56,7 @@ class SyncFacade(
         prisonCode = it.prisonCode,
         identifier = it.prisonTimeSlotId,
         source = Source.NOMIS,
-        user = userOrDefault(request.createdBy),
+        username = request.createdBy,
       )
     }
 
@@ -70,7 +67,7 @@ class SyncFacade(
         prisonCode = it.prisonCode,
         identifier = it.prisonTimeSlotId,
         source = Source.NOMIS,
-        user = userOrDefault(request.updatedBy),
+        username = request.updatedBy,
       )
     }
 
@@ -81,7 +78,7 @@ class SyncFacade(
         prisonCode = it.prisonCode,
         identifier = it.prisonTimeSlotId,
         source = Source.NOMIS,
-        user = UserService.getClientAsUser("NOMIS"),
+        username = "NOMIS",
       )
     }
   }
@@ -97,7 +94,7 @@ class SyncFacade(
         prisonCode = it.prisonCode,
         identifier = it.visitSlotId,
         source = Source.NOMIS,
-        user = userOrDefault(request.createdBy),
+        username = request.createdBy,
       )
     }
 
@@ -108,7 +105,7 @@ class SyncFacade(
         prisonCode = it.prisonCode,
         identifier = it.visitSlotId,
         source = Source.NOMIS,
-        user = userOrDefault(request.updatedBy),
+        username = request.updatedBy ?: "NOMIS",
       )
     }
 
@@ -120,7 +117,7 @@ class SyncFacade(
           prisonCode = it.prisonCode,
           identifier = it.visitSlotId,
           source = Source.NOMIS,
-          user = UserService.getClientAsUser("NOMIS"),
+          username = "NOMIS",
         )
       }
   }
@@ -137,7 +134,7 @@ class SyncFacade(
         identifier = it.officialVisitId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = userOrDefault(it.createdBy),
+        username = it.createdBy,
       )
     }
 
@@ -149,7 +146,7 @@ class SyncFacade(
         identifier = it.officialVisitId,
         noms = it.prisonerNumber,
         source = Source.NOMIS,
-        user = userOrDefault(it.updatedBy),
+        username = it.updatedBy ?: "NOMIS",
       )
     }
 
@@ -162,8 +159,9 @@ class SyncFacade(
           identifier = deletedOfficialVisit.officialVisitId,
           source = Source.NOMIS,
           noms = deletedOfficialVisit.prisonerNumber,
-          user = UserService.getClientAsUser("NOMIS"),
+          username = "NOMIS",
         )
+
         deletedOfficialVisit.visitors.forEach { visitor ->
           outboundEventsService.send(
             outboundEvent = OutboundEvent.VISITOR_DELETED,
@@ -172,7 +170,7 @@ class SyncFacade(
             secondIdentifier = visitor.officialVisitorId,
             contactId = visitor.contactId,
             source = Source.NOMIS,
-            user = UserService.getClientAsUser("NOMIS"),
+            username = "NOMIS",
           )
         }
       }
@@ -189,7 +187,7 @@ class SyncFacade(
       secondIdentifier = response.officialVisitorId,
       contactId = response.visitor.contactId,
       source = Source.NOMIS,
-      user = userOrDefault(response.visitor.createdBy),
+      username = response.visitor.createdBy,
     )
     return response.visitor
   }
@@ -203,7 +201,7 @@ class SyncFacade(
       secondIdentifier = response.officialVisitorId,
       contactId = response.visitor.contactId,
       source = Source.NOMIS,
-      user = userOrDefault(response.visitor.updatedBy),
+      username = response.visitor.updatedBy ?: "NOMIS",
     )
     return response.visitor
   }
@@ -217,12 +215,8 @@ class SyncFacade(
         secondIdentifier = response.officialVisitorId,
         contactId = response.contactId,
         source = Source.NOMIS,
-        user = UserService.getClientAsUser("NOMIS"),
+        username = "NOMIS",
       )
     }
   }
-
-  private fun userOrDefault(username: String? = null): User = username?.let { enrichIfPossible(username) } ?: UserService.getServiceAsUser()
-
-  private fun enrichIfPossible(username: String): User? = userService.getUser(username)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/outbound/OutboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/outbound/OutboundEventsService.kt
@@ -17,6 +17,7 @@ class OutboundEventsService(
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  // Overloaded method for calls from the UI including a User object via the OfficialVisitsFacade
   fun send(
     outboundEvent: OutboundEvent,
     prisonCode: String,
@@ -26,6 +27,27 @@ class OutboundEventsService(
     contactId: Long? = null,
     source: Source = Source.DPS,
     user: User,
+  ) = send(
+    outboundEvent,
+    prisonCode,
+    identifier,
+    secondIdentifier,
+    noms,
+    contactId,
+    source,
+    user.username,
+  )
+
+  // Standard method - for direct calls via the SyncFacade with no User object
+  fun send(
+    outboundEvent: OutboundEvent,
+    prisonCode: String,
+    identifier: Long,
+    secondIdentifier: Long? = 0,
+    noms: String = "",
+    contactId: Long? = null,
+    source: Source = Source.DPS,
+    username: String,
   ) {
     if (featureSwitches.isEnabled(outboundEvent)) {
       log.info("Sending event $outboundEvent source $source identifier $identifier secondIdentifier ${secondIdentifier ?: "N/A"} noms $noms contactId ${contactId ?: "N/A"} ")
@@ -38,7 +60,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            VisitInfo(identifier, source, user.username, prisonCode),
+            VisitInfo(identifier, source, username, prisonCode),
             PersonReference(noms),
           )
         }
@@ -49,7 +71,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            VisitorInfo(identifier, secondIdentifier ?: 0, source, user.username, prisonCode),
+            VisitorInfo(identifier, secondIdentifier ?: 0, source, username, prisonCode),
             contactId?.let { PersonReference(contactId = it) },
           )
         }
@@ -58,7 +80,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            PrisonerInfo(identifier, secondIdentifier ?: 0, source, user.username, prisonCode),
+            PrisonerInfo(identifier, secondIdentifier ?: 0, source, username, prisonCode),
             PersonReference(noms),
           )
         }
@@ -69,7 +91,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            TimeSlotInfo(identifier, source, user.username, prisonCode),
+            TimeSlotInfo(identifier, source, username, prisonCode),
           )
         }
 
@@ -79,7 +101,7 @@ class OutboundEventsService(
         -> {
           sendSafely(
             outboundEvent,
-            VisitSlotInfo(identifier, source, user.username, prisonCode),
+            VisitSlotInfo(identifier, source, username, prisonCode),
           )
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/sync/SyncFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/sync/SyncFacadeTest.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sync.SyncOf
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sync.SyncOfficialVisitorDeletionInfo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sync.SyncTimeSlot
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sync.SyncVisitSlot
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.OutboundEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.OutboundEventsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
@@ -61,7 +60,6 @@ class SyncFacadeTest {
   private val syncOfficialVisitService: SyncOfficialVisitService = mock()
   private val syncOfficialVisitorService: SyncOfficialVisitorService = mock()
   private val outboundEventsService: OutboundEventsService = mock()
-  private val userService: UserService = mock()
 
   private val facade = SyncFacade(
     syncTimeSlotService,
@@ -69,7 +67,6 @@ class SyncFacadeTest {
     syncOfficialVisitService,
     syncOfficialVisitorService,
     outboundEventsService,
-    userService,
   )
 
   private val createdTime = LocalDateTime.now().minusDays(2)
@@ -77,7 +74,6 @@ class SyncFacadeTest {
 
   @BeforeEach
   fun beforeEach() {
-    whenever(userService.getUser(MOORLAND_PRISON_USER.username)).thenReturn(MOORLAND_PRISON_USER)
     whenever(
       outboundEventsService.send(
         outboundEvent = any(),
@@ -87,7 +83,7 @@ class SyncFacadeTest {
         noms = anyOrNull(),
         contactId = anyOrNull(),
         source = any(),
-        user = any(),
+        username = any(),
       ),
     ).then {}
   }
@@ -100,7 +96,6 @@ class SyncFacadeTest {
       syncOfficialVisitService,
       syncOfficialVisitorService,
       outboundEventsService,
-      userService,
     )
   }
 
@@ -123,7 +118,7 @@ class SyncFacadeTest {
         prisonCode = result.prisonCode,
         identifier = result.prisonTimeSlotId,
         source = Source.NOMIS,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 
@@ -149,7 +144,7 @@ class SyncFacadeTest {
         noms = anyOrNull(),
         contactId = anyOrNull(),
         source = any(),
-        user = any(),
+        username = any(),
       )
     }
 
@@ -169,7 +164,7 @@ class SyncFacadeTest {
         prisonCode = result.prisonCode,
         identifier = result.prisonTimeSlotId,
         source = Source.NOMIS,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 
@@ -204,7 +199,7 @@ class SyncFacadeTest {
         prisonCode = MOORLAND,
         identifier = response.prisonTimeSlotId,
         source = Source.NOMIS,
-        user = UserService.getClientAsUser("NOMIS"),
+        username = "NOMIS",
       )
     }
 
@@ -264,7 +259,7 @@ class SyncFacadeTest {
         prisonCode = MOORLAND,
         identifier = result.visitSlotId,
         source = Source.NOMIS,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 
@@ -306,7 +301,7 @@ class SyncFacadeTest {
         prisonCode = MOORLAND,
         identifier = result.visitSlotId,
         source = Source.NOMIS,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 
@@ -339,7 +334,7 @@ class SyncFacadeTest {
         prisonCode = MOORLAND,
         identifier = response.visitSlotId,
         source = Source.NOMIS,
-        user = UserService.getClientAsUser("NOMIS"),
+        username = "NOMIS",
       )
     }
 
@@ -391,7 +386,7 @@ class SyncFacadeTest {
         source = Source.NOMIS,
         identifier = officialVisitId,
         noms = MOORLAND_PRISONER.number,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 
@@ -428,7 +423,7 @@ class SyncFacadeTest {
         source = Source.NOMIS,
         identifier = officialVisitId,
         noms = MOORLAND_PRISONER.number,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 
@@ -486,7 +481,7 @@ class SyncFacadeTest {
         source = Source.NOMIS,
         identifier = 1L, // official visit ID
         noms = "A1234AA",
-        user = UserService.getClientAsUser("NOMIS"),
+        username = "NOMIS",
       )
 
       verify(outboundEventsService, atLeastOnce()).send(
@@ -496,7 +491,7 @@ class SyncFacadeTest {
         identifier = 1L, // official visit ID
         secondIdentifier = 1L, // official visitor ID
         contactId = 2L,
-        user = UserService.getClientAsUser("NOMIS"),
+        username = "NOMIS",
       )
     }
 
@@ -604,7 +599,7 @@ class SyncFacadeTest {
         identifier = officialVisitId,
         secondIdentifier = officialVisitorId,
         contactId = contactId,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 
@@ -664,7 +659,7 @@ class SyncFacadeTest {
         identifier = officialVisitId,
         secondIdentifier = officialVisitorId,
         contactId = contactId,
-        user = UserService.getClientAsUser("NOMIS"),
+        username = "NOMIS",
       )
     }
 
@@ -699,7 +694,7 @@ class SyncFacadeTest {
         identifier = officialVisitId,
         secondIdentifier = officialVisitorId,
         contactId = contactId,
-        user = MOORLAND_PRISON_USER,
+        username = MOORLAND_PRISON_USER.username,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncVisitSlotIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncVisitSlotIntegrationTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync.SyncUpd
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.CreateOfficialVisitResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sync.SyncVisitSlot
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.OutboundEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Source
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.VisitSlotInfo
@@ -88,7 +87,7 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
       additionalInfo = VisitSlotInfo(
         visitSlotId = syncVisitSlot.visitSlotId,
         source = Source.NOMIS,
-        username = "OFFICIAL_VISITS_SERVICE",
+        username = "NOMIS-CREATE-USER",
         prisonId = MOORLAND,
       ),
     )
@@ -119,7 +118,7 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
       additionalInfo = VisitSlotInfo(
         visitSlotId = syncVisitSlot.visitSlotId,
         source = Source.NOMIS,
-        username = "OFFICIAL_VISITS_SERVICE",
+        username = "NOMIS-UPDATE-USER",
         prisonId = MOORLAND,
       ),
     )
@@ -157,6 +156,7 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
   @Test
   fun `should delete visit slot if there are no associated official visits`() {
     val syncVisitSlot = webTestClient.createVisitSlot()
+    stubEvents.reset()
 
     webTestClient.delete()
       .uri("/sync/visit-slot/{prisonVisitSlotId}", syncVisitSlot.visitSlotId)
@@ -167,21 +167,11 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
       .is2xxSuccessful
 
     stubEvents.assertHasEvent(
-      event = OutboundEvent.VISIT_SLOT_CREATED,
-      additionalInfo = VisitSlotInfo(
-        visitSlotId = syncVisitSlot.visitSlotId,
-        source = Source.NOMIS,
-        username = "OFFICIAL_VISITS_SERVICE",
-        prisonId = MOORLAND,
-      ),
-    )
-
-    stubEvents.assertHasEvent(
       event = OutboundEvent.VISIT_SLOT_DELETED,
       additionalInfo = VisitSlotInfo(
         visitSlotId = syncVisitSlot.visitSlotId,
         source = Source.NOMIS,
-        username = UserService.getClientAsUser("NOMIS").username,
+        username = "NOMIS", // Does not specify a user in the request so defaults to NOMIS
         prisonId = MOORLAND,
       ),
     )
@@ -224,13 +214,13 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
     prisonTimeSlotId = 1L,
     dpsLocationId = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
     maxAdults = 10,
-    createdBy = "Test",
+    createdBy = "NOMIS-CREATE-USER",
     createdTime = createdTime,
   )
 
   private fun updateVisitSlotRequest() = SyncUpdateVisitSlotRequest(
     dpsLocationId = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
-    updatedBy = "Test",
+    updatedBy = "NOMIS-UPDATE-USER",
     maxAdults = 15,
     updatedTime = updatedTime,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncTimeSlotServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncTimeSlotServiceTest.kt
@@ -10,7 +10,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever


### PR DESCRIPTION
For some sync calls (create and update visits and visitors) this service was making calls to the manage-users-api after the database transaction had already committed, and failing to catch any exceptions if this call failed. 

A few issues:
* We've already committed the synced data, but then fail and return a 500 error to the sync service
* The sync service can't try again as the data now already exists
* The sync service received an error response - so it can't create any mapping data (doesn't know the IDs we assigned)
* We weren't catching the WebClientTimeOutException - so using a generic 500, with no indication why it failed.

This PR addresses some of these:
* We no longer call the manage-users-api outside the Transactional method, only inside it. 
* If we fail to retrieve the user, we'll fail the transaction and any retries will succeed.
* These changes only apply to the sync calls from Syscon - those made via the SyncFacade.
* They do not apply to UI calls made via the OfficalVisitsFacade.

Follow on work
* Catch the potential WebClientTimeOutException from the call to the manage-users-api (in the exception handler) and build a more appropriate response (408 TimeoutResponse) for sync service calls. 
* Create a specific exception class for User not found in the manage-users-api. It is currently using EntityNotFoundException and a 404 response, which is not really correct for an issue downstream of us. 
* Look at the OfficialVisitsFacade, to check if the calls to manage-users-api are outside of the DB transaction, as these could fail in the response to the UI but still commit the data.