### PR TITLE
OV-579 : handle validation error on enum

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/OfficialVisitsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/OfficialVisitsApiExceptionHandler.kt
@@ -9,10 +9,12 @@ import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import tools.jackson.databind.exc.InvalidFormatException
 import uk.gov.justice.digital.hmpps.officialvisitsapi.exception.DuplicateOffenderVisitIdConflictException
 import uk.gov.justice.digital.hmpps.officialvisitsapi.exception.DuplicateOffenderVisitIdErrorResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.exception.EntityInUseException
@@ -122,6 +124,26 @@ class OfficialVisitsApiExceptionHandler {
         e.message,
       ),
     )
+
+  @ExceptionHandler(HttpMessageNotReadableException::class)
+  fun handleHttpMessageNotReadable(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
+    val cause = e.cause
+    val message = if (cause is InvalidFormatException && cause.targetType.isEnum) {
+      val field = cause.path.joinToString(".") { it.propertyName ?: "[${it.index}]" }
+      val allowed = cause.targetType.enumConstants.joinToString(", ")
+      "Validation failed: `$field` must be one of: $allowed"
+    } else {
+      "Validation failure: Couldn't read request body"
+    }
+
+    return ResponseEntity.status(BAD_REQUEST).body(
+      ErrorResponse(
+        status = BAD_REQUEST,
+        userMessage = message,
+        developerMessage = e.message,
+      ),
+    ).also { log.error(message, e) }
+  }
 
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCancellationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCancellationIntegrationTest.kt
@@ -179,6 +179,20 @@ class OfficialVisitCancellationIntegrationTest : IntegrationTestBase() {
     }
   }
 
+  @Test
+  fun `should return validation message when cancellation reason enum is invalid`() {
+    val expectedMessage = "Validation failed: `cancellationReason` must be one of: ${VisitCompletionType.entries.joinToString(", ")}"
+
+    webTestClient.badCancel(
+      officialVisitId = 999_999,
+      request = mapOf(
+        "cancellationReason" to "INVALID_REASON",
+        "cancellationNotes" to "invalid enum integration test",
+      ),
+      errorMessage = expectedMessage,
+    )
+  }
+
   private fun WebTestClient.cancel(officialVisitId: Long, request: OfficialVisitCancellationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
     .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId/cancel")
@@ -187,4 +201,20 @@ class OfficialVisitCancellationIntegrationTest : IntegrationTestBase() {
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
     .exchange()
     .expectStatus().isOk
+
+  private fun WebTestClient.badCancel(
+    officialVisitId: Long,
+    request: Any,
+    errorMessage: String,
+    prisonUser: PrisonUser = MOORLAND_PRISON_USER,
+  ) = this
+    .post()
+    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId/cancel")
+    .bodyValue(request)
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
+    .exchange()
+    .expectStatus().isBadRequest
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody().jsonPath("$.userMessage").isEqualTo(errorMessage)
 }


### PR DESCRIPTION
Test evidence:
<img width="1156" height="507" alt="image" src="https://github.com/user-attachments/assets/e2490ece-551a-4e75-813e-c8556dce09ef" />
This pull request improves error handling for invalid enum values in request bodies and adds integration tests to ensure the new behaviour. The main changes include enhanced exception handling for enum validation failures and the addition of tests to verify that users receive clear validation messages when submitting invalid enum values.
