### PR TITLE
OV-582: Populate allowed caseloads for a user.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/client/manageusers/ManageUsersClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/client/manageusers/ManageUsersClient.kt
@@ -1,13 +1,16 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers
 
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
 import reactor.util.retry.Retry
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserCaseloadDetail
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto
+import uk.gov.justice.digital.hmpps.officialvisitsapi.config.CacheConfiguration
 import java.time.Duration
 
 @Component
@@ -17,17 +20,14 @@ class ManageUsersClient(private val manageUsersApiWebClient: WebClient) {
   }
 
   /**
-   * This will attempt to find the user details for this username.
+   * This will attempt to find the user details for a provided username.
    * If it receives a 404 Not Found response it will return a null immediately without retrying.
    * It will wait a maximum of 5 seconds for a response on each call
    * If an exception is encountered e.g. timeout, or connection error, it will retry upto 3 further times.
    * Each retry will double the previous back-off time, so after 250ms, 500ms and 1000ms
    * If it still fails it will return null and swallow any exceptions, not propagate them.
    */
-  // TODO: Look into different caching options - currently the user details are looking up per request
-  // TODO: but there are issues when a user switches their caseload (the cached copy keeps the old active caseload)
-  // TODO: And activeCaseload is deprecated in the response here....  rethink this area.
-  // @Cacheable(CacheConfiguration.USER_DETAILS_BY_USERNAME_CACHE)
+  @Cacheable(CacheConfiguration.USER_DETAILS_BY_USERNAME_CACHE)
   fun getUsersDetails(username: String): UserDetailsDto? = manageUsersApiWebClient
     .get()
     .uri("/users/{username}", username)
@@ -36,6 +36,21 @@ class ManageUsersClient(private val manageUsersApiWebClient: WebClient) {
     .timeout(Duration.ofSeconds(5))
     .retryWhen(Retry.backoff(3, Duration.ofMillis(250)).filter { it !is WebClientResponseException.NotFound })
     .doOnError { error -> log.info("Error looking up user details by username $username in manage users client", error) }
+    .onErrorResume { Mono.empty() }
+    .block()
+
+  /**
+   * Get the list of all caseloads for a username
+   */
+  @Cacheable(CacheConfiguration.USER_CASELOADS_BY_USERNAME_CACHE)
+  fun getUserCaseloads(username: String): UserCaseloadDetail? = manageUsersApiWebClient
+    .get()
+    .uri("/prisonusers/{username}/caseloads", username)
+    .retrieve()
+    .bodyToMono<UserCaseloadDetail>()
+    .timeout(Duration.ofSeconds(5))
+    .retryWhen(Retry.backoff(3, Duration.ofMillis(250)).filter { it !is WebClientResponseException.NotFound })
+    .doOnError { error -> log.info("Error looking up user caseload details by username $username in manage users client", error) }
     .onErrorResume { Mono.empty() }
     .block()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/CacheConfiguration.kt
@@ -23,6 +23,7 @@ class CacheConfiguration {
     const val OFFICIAL_VISIT_LOCATIONS_BY_PRISON_CACHE = "official-visit-locations-by-prison"
     const val REFERENCE_DATA_BY_GROUP_AND_CODE_CACHE = "reference-data-by-group-and-code"
     const val USER_DETAILS_BY_USERNAME_CACHE = "user-details-by-username"
+    const val USER_CASELOADS_BY_USERNAME_CACHE = "user-caseloads-by-username"
     const val FIFTEEN = 15L
   }
 
@@ -31,6 +32,7 @@ class CacheConfiguration {
     OFFICIAL_VISIT_LOCATIONS_BY_PRISON_CACHE,
     REFERENCE_DATA_BY_GROUP_AND_CODE_CACHE,
     USER_DETAILS_BY_USERNAME_CACHE,
+    USER_CASELOADS_BY_USERNAME_CACHE,
   )
 
   @CacheEvict(value = [OFFICIAL_VISIT_LOCATIONS_BY_PRISON_CACHE], allEntries = true)
@@ -49,5 +51,11 @@ class CacheConfiguration {
   @Scheduled(fixedDelay = 2, timeUnit = TimeUnit.HOURS)
   fun cacheEvictUserDetailsByUsername() {
     log.info("Evicting cache: $USER_DETAILS_BY_USERNAME_CACHE after 2 hours")
+  }
+
+  @CacheEvict(value = [USER_CASELOADS_BY_USERNAME_CACHE], allEntries = true)
+  @Scheduled(fixedDelay = 2, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictUserCaseloadsByUsername() {
+    log.info("Evicting cache: $USER_CASELOADS_BY_USERNAME_CACHE after 2 hours")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/LocalRequestContextConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/LocalRequestContextConfiguration.kt
@@ -41,7 +41,7 @@ class LocalRequestContextInterceptor(private val userService: UserService) : Han
     if (username != null) {
       request.setAttribute(
         LocalRequestContext::class.simpleName,
-        LocalRequestContext(user = userService.getUser(username) ?: throw AccessDeniedException("User with username $username not found")),
+        LocalRequestContext(user = userService.getUser(username) ?: throw AccessDeniedException("User with username $username not found or not allowed")),
       )
     } else {
       // The clientId is non-nullable, otherwise the request would not be authenticated!

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
@@ -41,11 +41,7 @@ class OfficialVisitFacade(
   ): CreateOfficialVisitResponse = run {
     require(user is PrisonUser) { "Visits can only be created by a digital prison user" }
 
-    checkPrisonUsersActiveCaseload(
-      prisonCode,
-      user,
-      "This visit cannot be created in a prison which is not the active caseload for the user",
-    )
+    checkPrisonUsersCaseloads(prisonCode, user, "This visit cannot be created in a prison outside the user's caseload list")
 
     officialVisitCreateService.create(prisonCode, request, user).also { creationResult ->
       outboundEventsService.send(
@@ -180,11 +176,7 @@ class OfficialVisitFacade(
   fun updateVisitors(officialVisitId: Long, prisonCode: String, request: OfficialVisitUpdateVisitorsRequest, user: User) {
     require(user is PrisonUser) { "Visits can only be updated by a digital prison user" }
 
-    checkPrisonUsersActiveCaseload(
-      prisonCode,
-      user,
-      "This visit cannot be updated in a prison which is not the active caseload for the user",
-    )
+    checkPrisonUsersCaseloads(prisonCode, user, "This visit cannot be updated in a prison which is not the active caseload for the user")
 
     val ov = officialVisitUpdateService.updateVisitors(officialVisitId, prisonCode, request, user)
 
@@ -232,8 +224,8 @@ class OfficialVisitFacade(
 
   fun findOverlappingScheduledVisits(prisonCode: String, request: OverlappingVisitsCriteriaRequest) = overlappingVisitsService.findOverlappingScheduledVisits(prisonCode, request)
 
-  private fun checkPrisonUsersActiveCaseload(prisonCode: String, user: PrisonUser, message: String) {
-    if (prisonCode.trim().uppercase() != user.activeCaseLoadId?.trim()?.uppercase()) {
+  private fun checkPrisonUsersCaseloads(prisonCode: String, user: PrisonUser, message: String) {
+    if (prisonCode.trim().uppercase() !in user.caseloads) {
       throw CaseloadAccessException(message)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
@@ -176,7 +176,7 @@ class OfficialVisitFacade(
   fun updateVisitors(officialVisitId: Long, prisonCode: String, request: OfficialVisitUpdateVisitorsRequest, user: User) {
     require(user is PrisonUser) { "Visits can only be updated by a digital prison user" }
 
-    checkPrisonUsersCaseloads(prisonCode, user, "This visit cannot be updated in a prison which is not the active caseload for the user")
+    checkPrisonUsersCaseloads(prisonCode, user, "This visit cannot be updated in a prison outside the user's caseload list")
 
     val ov = officialVisitUpdateService.updateVisitors(officialVisitId, prisonCode, request, user)
 
@@ -225,7 +225,7 @@ class OfficialVisitFacade(
   fun findOverlappingScheduledVisits(prisonCode: String, request: OverlappingVisitsCriteriaRequest) = overlappingVisitsService.findOverlappingScheduledVisits(prisonCode, request)
 
   private fun checkPrisonUsersCaseloads(prisonCode: String, user: PrisonUser, message: String) {
-    if (prisonCode.trim().uppercase() !in user.caseloads) {
+    if (!user.hasCaseloadAccess(prisonCode)) {
       throw CaseloadAccessException(message)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/ResourceAnnotations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/ResourceAnnotations.kt
@@ -41,7 +41,7 @@ annotation class ProtectedByIngress
   value = [
     ApiResponse(
       responseCode = "409",
-      description = "Conflict, requires users active caseload to match that of the prison",
+      description = "Conflict, requires caseload access to the prison",
       content = [Content(schema = Schema(implementation = ErrorResponse::class))],
     ),
   ],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/UserService.kt
@@ -68,6 +68,8 @@ abstract class User(val username: String, val name: String) {
  */
 class PrisonUser(username: String, name: String, val caseloads: List<String>) : User(username, name) {
 
+  fun hasCaseloadAccess(prisonCode: String) = prisonCode.trim().uppercase() in caseloads
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/UserService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/UserService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.ManageUsersClient
@@ -10,39 +11,43 @@ import java.util.Objects
 class UserService(private val manageUsersClient: ManageUsersClient) {
 
   companion object {
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     private enum class ServiceName {
       OFFICIAL_VISITS_SERVICE,
     }
 
-    private val serviceUser = ServiceUser(
-      ServiceName.OFFICIAL_VISITS_SERVICE.name,
-      ServiceName.OFFICIAL_VISITS_SERVICE.name,
-    )
-
-    fun getServiceAsUser() = serviceUser
+    fun getServiceAsUser() = ServiceUser(ServiceName.OFFICIAL_VISITS_SERVICE.name, ServiceName.OFFICIAL_VISITS_SERVICE.name)
 
     fun getClientAsUser(clientId: String) = ServiceUser(username = clientId, name = clientId)
   }
 
-  fun getUser(username: String): User? = manageUsersClient.getUsersDetails(username)?.let { userDetails ->
-    when (userDetails.authSource) {
-      AuthSource.nomis -> {
-        PrisonUser(
-          username = username,
-          name = userDetails.name,
-          activeCaseLoadId = userDetails.activeCaseLoadId,
-        )
-      }
-      else -> throw AccessDeniedException("Users with auth source ${userDetails.authSource} are not supported by this service")
+  fun getUser(username: String): User? {
+    val userDetailsDto = manageUsersClient.getUsersDetails(username) ?: return null
+
+    if (!userDetailsDto.active) {
+      throw AccessDeniedException("Inactive user account $username")
     }
+
+    if (userDetailsDto.authSource != AuthSource.nomis) {
+      throw AccessDeniedException("User $username with auth source ${userDetailsDto.authSource} is not supported by this service")
+    }
+
+    val userCaseloads = manageUsersClient.getUserCaseloads(username) ?: return null
+
+    return PrisonUser(
+      username = username,
+      name = userDetailsDto.name,
+      caseloads = userCaseloads.caseloads.map { caseload -> caseload.id.trim().uppercase() },
+    )
   }
 }
 
-abstract class User(
-  val username: String,
-  val name: String,
-) {
+/**
+ * The abstract User class that is subclassed by PrisonUser and ServiceUser
+ */
+abstract class User(val username: String, val name: String) {
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false
@@ -58,28 +63,29 @@ abstract class User(
   override fun hashCode() = Objects.hash(username, name)
 }
 
-class PrisonUser(
-  val activeCaseLoadId: String? = null,
-  username: String,
-  name: String,
-) : User(username, name) {
+/**
+ * A real prison staff member with a username, full name and a list of caseloads (prison codes) they have access to.
+ */
+class PrisonUser(username: String, name: String, val caseloads: List<String>) : User(username, name) {
+
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (javaClass != other?.javaClass) return false
     if (!super.equals(other)) return false
 
     other as PrisonUser
-
-    if (activeCaseLoadId != other.activeCaseLoadId) return false
-
-    return true
+    return caseloads == other.caseloads
   }
 
   override fun hashCode(): Int {
     var result = super.hashCode()
-    result = 31 * result + (activeCaseLoadId?.hashCode() ?: 0)
+    result = (((31 * result + caseloads.hashCode())))
     return result
   }
 }
 
+/**
+ * The user is a service user, with no human involved. The UI or API has not provided a reference to an actual person.
+ * Caseload checks are not necessary for service users.
+ */
 class ServiceUser(username: String, name: String) : User(username, name)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/client/manageusers/ManageUsersClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/client/manageusers/ManageUsersClientTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.userCaseloads
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.userDetails
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.wiremock.ManageUsersApiMockServer
 
@@ -16,6 +17,13 @@ class ManageUsersClientTest {
     server.stubGetUserDetails("username", name = "name")
 
     client.getUsersDetails("username") isEqualTo userDetails("username", "name")
+  }
+
+  @Test
+  fun `should get users caseloads`() {
+    server.stubGetUserCaseloads("username")
+
+    client.getUserCaseloads("username") isEqualTo userCaseloads("username", true)
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/LocalRequestContextConfigurationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/LocalRequestContextConfigurationTest.kt
@@ -63,7 +63,7 @@ class LocalRequestContextConfigurationTest {
 
     val exception = assertThrows<AccessDeniedException> { interceptor.preHandle(req, res, "null") }
 
-    exception.message isEqualTo "User with username USER_NAME not found"
+    exception.message isEqualTo "User with username USER_NAME not found or not allowed"
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
@@ -267,6 +267,6 @@ class OfficialVisitFacadeTest {
     assertThrows<CaseloadAccessException> {
       facade.updateVisitors(1, MOORLAND, request, PENTONVILLE_PRISON_USER)
     }
-      .message isEqualTo "This visit cannot be updated in a prison which is not the active caseload for the user"
+      .message isEqualTo "This visit cannot be updated in a prison outside the user's caseload list"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
@@ -135,7 +135,7 @@ class OfficialVisitFacadeTest {
     assertThrows<CaseloadAccessException> {
       facade.createOfficialVisit(MOORLAND, request, PENTONVILLE_PRISON_USER)
     }
-      .message isEqualTo "This visit cannot be created in a prison which is not the active caseload for the user"
+      .message isEqualTo "This visit cannot be created in a prison outside the user's caseload list"
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/ModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/ModelFactory.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.helper
 
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.locationsinsideprison.model.Location
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.locationsinsideprison.model.NonResidentialUsageDto
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.PrisonCaseload
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserCaseloadDetail
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.personalrelationships.model.PageMetadata
@@ -69,25 +71,39 @@ fun userDetails(
   username: String,
   name: String = "Test User",
   authSource: AuthSource = AuthSource.auth,
-  activeCaseLoadId: String? = null,
+  activeCaseLoadId: String? = null, // deprecated
   userId: String = "TEST",
+  active: Boolean = true,
 ) = UserDetailsDto(
   userId = userId,
   username = username,
-  active = true,
+  active = active,
   name = name,
   authSource = authSource,
   activeCaseLoadId = activeCaseLoadId,
 )
 
+fun userCaseloads(
+  username: String,
+  active: Boolean = true,
+  activeCaseload: PrisonCaseload = PrisonCaseload(id = BIRMINGHAM, name = "Birmingham"),
+  caseloads: List<PrisonCaseload> = listOf(PrisonCaseload(id = BIRMINGHAM, name = "Birmingham")),
+) = UserCaseloadDetail(
+  username = username,
+  active = active,
+  accountType = UserCaseloadDetail.AccountType.GENERAL,
+  activeCaseload = activeCaseload,
+  caseloads = caseloads,
+)
+
 fun prisonUser(
   username: String = "prison_user",
   name: String = "Prison User",
-  activeCaseLoadId: String = BIRMINGHAM,
+  caseloads: List<String> = listOf(BIRMINGHAM),
 ) = PrisonUser(
   username = username,
   name = name,
-  activeCaseLoadId = activeCaseLoadId,
+  caseloads = caseloads,
 )
 
 fun prisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/TestApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/TestApiClient.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 class TestApiClient(private val webTestClient: WebTestClient, private val jwtAuthHelper: JwtAuthorisationHelper) {
   fun createOfficialVisit(request: CreateOfficialVisitRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = webTestClient
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(prisonUser, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
@@ -26,7 +26,7 @@ class TestApiClient(private val webTestClient: WebTestClient, private val jwtAut
 
   fun getOfficialVisitBy(officialVisitId: Long, prisonUser: PrisonUser) = webTestClient
     .get()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/id/$officialVisitId")
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(prisonUser, roles = listOf("ROLE_OFFICIAL_VISITS__R")))
     .exchange()
@@ -37,7 +37,7 @@ class TestApiClient(private val webTestClient: WebTestClient, private val jwtAut
 
   fun cancel(officialVisitId: Long, request: OfficialVisitCancellationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = webTestClient
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId/cancel")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/id/$officialVisitId/cancel")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(prisonUser, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
@@ -46,7 +46,7 @@ class TestApiClient(private val webTestClient: WebTestClient, private val jwtAut
 
   fun complete(officialVisitId: Long, request: OfficialVisitCompletionRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = webTestClient
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId/complete")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/id/$officialVisitId/complete")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(prisonUser, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/Users.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/Users.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.helper
 
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 
-val PENTONVILLE_PRISON_USER = prisonUser(activeCaseLoadId = PENTONVILLE)
-val MOORLAND_PRISON_USER = prisonUser(activeCaseLoadId = MOORLAND)
+val PENTONVILLE_PRISON_USER = prisonUser(caseloads = listOf(PENTONVILLE))
+val MOORLAND_PRISON_USER = prisonUser(caseloads = listOf(MOORLAND))
 val SERVICE_USER = UserService.getServiceAsUser()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
@@ -12,8 +12,10 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.PrisonCaseload
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto
 import uk.gov.justice.digital.hmpps.officialvisitsapi.health.LocationsInsidePrisonApiHealthPingCheck
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.TestApiClient
@@ -87,7 +89,18 @@ abstract class IntegrationTestBase {
   }
 
   protected fun stubUser(user: PrisonUser) {
-    manageUsersApi().stubGetUserDetails(username = user.username, authSource = UserDetailsDto.AuthSource.nomis, name = user.name, activeCaseload = user.activeCaseLoadId)
+    manageUsersApi().stubGetUserDetails(
+      username = user.username,
+      authSource = UserDetailsDto.AuthSource.nomis,
+      name = user.name,
+      activeCaseload = user.caseloads.first(),
+    )
+
+    manageUsersApi().stubGetUserCaseloads(
+      username = user.username,
+      activeCaseload = PrisonCaseload(user.caseloads.first(), name = ""),
+      caseloads = listOf(PrisonCaseload(user.caseloads.first(), name = "")),
+    )
   }
 
   internal fun setAuthorisation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
@@ -15,7 +15,6 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.PrisonCaseload
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto
 import uk.gov.justice.digital.hmpps.officialvisitsapi.health.LocationsInsidePrisonApiHealthPingCheck
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.TestApiClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/CreateOfficialVisitIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/CreateOfficialVisitIntegrationTest.kt
@@ -192,7 +192,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.VISIT_CREATED,
-      additionalInfo = VisitInfo(persistedOfficialVisit.officialVisitId, Source.DPS, MOORLAND_PRISON_USER.username, MOORLAND_PRISON_USER.activeCaseLoadId),
+      additionalInfo = VisitInfo(persistedOfficialVisit.officialVisitId, Source.DPS, MOORLAND_PRISON_USER.username, MOORLAND_PRISON_USER.caseloads.first()),
       personReference = PersonReference(nomsNumber = MOORLAND_PRISONER.number),
     )
 
@@ -272,7 +272,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.VISIT_CREATED,
-      additionalInfo = VisitInfo(persistedOfficialVisit.officialVisitId, Source.DPS, MOORLAND_PRISON_USER.username, MOORLAND_PRISON_USER.activeCaseLoadId),
+      additionalInfo = VisitInfo(persistedOfficialVisit.officialVisitId, Source.DPS, MOORLAND_PRISON_USER.username, MOORLAND_PRISON_USER.caseloads.first()),
       personReference = PersonReference(nomsNumber = MOORLAND_PRISONER.number),
     )
 
@@ -373,7 +373,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
       prisonCode = MOORLAND,
       prisonUser = PENTONVILLE_PRISON_USER,
       request = nextMondayAt9,
-      errorMessage = "This visit cannot be created in a prison which is not the active caseload for the user",
+      errorMessage = "This visit cannot be created in a prison outside the user's caseload list",
     )
 
     stubEvents.assertHasNoEvents(event = OutboundEvent.VISIT_CREATED)
@@ -381,7 +381,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.create(request: CreateOfficialVisitRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
@@ -393,7 +393,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.badRequest(request: CreateOfficialVisitRequest, errorMessage: String, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCancellationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCancellationIntegrationTest.kt
@@ -195,7 +195,7 @@ class OfficialVisitCancellationIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.cancel(officialVisitId: Long, request: OfficialVisitCancellationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId/cancel")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/id/$officialVisitId/cancel")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
@@ -209,7 +209,7 @@ class OfficialVisitCancellationIntegrationTest : IntegrationTestBase() {
     prisonUser: PrisonUser = MOORLAND_PRISON_USER,
   ) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId/cancel")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/id/$officialVisitId/cancel")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCompletionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitCompletionIntegrationTest.kt
@@ -191,7 +191,7 @@ class OfficialVisitCompletionIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.complete(officialVisitId: Long, request: OfficialVisitCompletionRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/id/$officialVisitId/complete")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/id/$officialVisitId/complete")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitSearchIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitSearchIntegrationTest.kt
@@ -173,7 +173,7 @@ class OfficialVisitSearchIntegrationTest : IntegrationTestBase() {
         info = eq(
           SearchInfo(
             username = MOORLAND_PRISON_USER.username,
-            prisonCode = MOORLAND_PRISON_USER.activeCaseLoadId!!,
+            prisonCode = MOORLAND_PRISON_USER.caseloads.first(),
             startDate = searchRequest.startDate!!,
             searchTerm = searchRequest.searchTerm?.trim(),
             endDate = searchRequest.endDate!!,
@@ -256,7 +256,7 @@ class OfficialVisitSearchIntegrationTest : IntegrationTestBase() {
         info = eq(
           SearchInfo(
             username = MOORLAND_PRISON_USER.username,
-            prisonCode = MOORLAND_PRISON_USER.activeCaseLoadId!!,
+            prisonCode = MOORLAND_PRISON_USER.caseloads.first(),
             startDate = searchRequest.startDate!!,
             searchTerm = searchRequest.searchTerm?.trim(),
             endDate = searchRequest.endDate!!,
@@ -546,7 +546,7 @@ class OfficialVisitSearchIntegrationTest : IntegrationTestBase() {
     size: Int = 1,
   ) = webTestClient
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/find-by-criteria?page=$page&size=$size")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/find-by-criteria?page=$page&size=$size")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
@@ -564,7 +564,7 @@ class OfficialVisitSearchIntegrationTest : IntegrationTestBase() {
     size: Int = 1,
   ) = webTestClient
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/find-by-criteria?page=$page&size=$size")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/find-by-criteria?page=$page&size=$size")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OverlappingVisitsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OverlappingVisitsIntegrationTest.kt
@@ -171,7 +171,7 @@ class OverlappingVisitsIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.check(request: OverlappingVisitsCriteriaRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}/overlapping")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}/overlapping")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/ReconciliationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/ReconciliationIntegrationTest.kt
@@ -244,7 +244,7 @@ class ReconciliationIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.create(request: CreateOfficialVisitRequest) = this
     .post()
-    .uri("/official-visit/prison/${MOORLAND_PRISON_USER.activeCaseLoadId}")
+    .uri("/official-visit/prison/${MOORLAND_PRISON_USER.caseloads.first()}")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
@@ -520,7 +520,7 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.createOfficialVisit(request: CreateOfficialVisitRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.PrisonCaseload
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.CONTACT_MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
@@ -78,6 +79,13 @@ class SyncOfficialVisitorsIntegrationTest : IntegrationTestBase() {
       MOORLAND_PRISON_USER.name,
       MOORLAND,
       MOORLAND_PRISON_USER.username,
+    )
+
+    manageUsersApi().stubGetUserCaseloads(
+      username = MOORLAND_PRISON_USER.username,
+      active = true,
+      activeCaseload = PrisonCaseload(id = MOORLAND, name = "Moorland"),
+      caseloads = listOf(PrisonCaseload(id = MOORLAND, name = "Moorland")),
     )
 
     // Stub a known contact

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncVisitSlotIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncVisitSlotIntegrationTest.kt
@@ -240,7 +240,7 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.createOfficialVisit(request: CreateOfficialVisitRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
-    .uri("/official-visit/prison/${prisonUser.activeCaseLoadId}")
+    .uri("/official-visit/prison/${prisonUser.caseloads.first()}")
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/wiremock/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/wiremock/ManageUsersApiMockServer.kt
@@ -7,7 +7,10 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.PrisonCaseload
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto.AuthSource
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.userCaseloads
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.userDetails
 import java.net.URLEncoder
 
@@ -26,6 +29,23 @@ class ManageUsersApiMockServer : MockServer(8093) {
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withBody(mapper.writeValueAsString(userDetails(username, name, authSource, activeCaseload, userId)))
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetUserCaseloads(
+    username: String,
+    active: Boolean = true,
+    activeCaseload: PrisonCaseload = PrisonCaseload(id = BIRMINGHAM, name = "Birmingham"),
+    caseloads: List<PrisonCaseload> = listOf(PrisonCaseload(id = BIRMINGHAM, name = "Birmingham")),
+  ) {
+    stubFor(
+      get("/prisonusers/${username.urlEncode()}/caseloads")
+        .willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(userCaseloads(username, active, activeCaseload, caseloads)))
             .withStatus(200),
         ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/UserServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/UserServiceTest.kt
@@ -9,13 +9,16 @@ import org.springframework.security.access.AccessDeniedException
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.ManageUsersClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.UserDetailsDto.AuthSource
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.userCaseloads
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.userDetails
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService.Companion.getClientAsUser
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService.Companion.getServiceAsUser
 
 class UserServiceTest {
-
   private val manageUsersClient: ManageUsersClient = mock()
   private val userService = UserService(manageUsersClient)
 
@@ -38,8 +41,9 @@ class UserServiceTest {
   @Test
   fun `getUser should return prison user when authSource is nomis`() {
     whenever(manageUsersClient.getUsersDetails("testUser")) doReturn userDetails("testUser", "Test User", authSource = AuthSource.nomis, activeCaseLoadId = BIRMINGHAM)
+    whenever(manageUsersClient.getUserCaseloads("testUser")) doReturn userCaseloads("testUser")
 
-    userService.getUser("testUser") as PrisonUser isEqualTo PrisonUser(username = "testUser", name = "Test User", activeCaseLoadId = BIRMINGHAM)
+    userService.getUser("testUser") as PrisonUser isEqualTo PrisonUser(username = "testUser", name = "Test User", caseloads = listOf(BIRMINGHAM))
   }
 
   @Test
@@ -48,7 +52,7 @@ class UserServiceTest {
 
     val exception = assertThrows<AccessDeniedException> { userService.getUser("testUser") }
 
-    exception.message isEqualTo "Users with auth source delius are not supported by this service"
+    exception.message isEqualTo "User testUser with auth source delius is not supported by this service"
   }
 
   @Test
@@ -59,8 +63,19 @@ class UserServiceTest {
   }
 
   @Test
+  fun `getUser should throw AccessDeniedException when the user account is not active`() {
+    whenever(manageUsersClient.getUsersDetails("testUser")) doReturn userDetails("testUser", "Test User", authSource = AuthSource.nomis, active = false, activeCaseLoadId = BIRMINGHAM)
+
+    val exception = assertThrows<AccessDeniedException> { userService.getUser("testUser") }
+
+    exception.message isEqualTo "Inactive user account testUser"
+  }
+
+  @Test
   fun `should create prison users`() {
-    PrisonUser(username = "username", name = "name")
-    PrisonUser(username = "username", name = "name", activeCaseLoadId = BIRMINGHAM)
+    val user1 = PrisonUser(username = "username", name = "name", caseloads = emptyList())
+    val user2 = PrisonUser(username = "username", name = "name", caseloads = listOf(BIRMINGHAM, MOORLAND, PENTONVILLE))
+    user1.caseloads hasSize 0
+    user2.caseloads hasSize 3
   }
 }


### PR DESCRIPTION
Allow official visit operations for any prison in the user's list of caseloads. 
Re-introduce caching for both manage-users-api calls.
This will cater for changes in caseload in the UI part-way through a visit journey.