### PR TITLE
OV-607 new notificatons endpoint supporting single API calls to send notifications.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/GovNotifyConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/GovNotifyConfiguration.kt
@@ -5,13 +5,18 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailTemplate
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailTemplates
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailType.OFFICIAL_VISIT_CREATED
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.GovNotifyEmailService
 import uk.gov.service.notify.NotificationClient
 import java.util.UUID
 
 @Configuration
-class GovNotifyConfiguration(@Value($$"${notify.api.key:}") private val apiKey: String) {
+class GovNotifyConfiguration(
+  @Value($$"${notify.api.key:}") private val apiKey: String,
+  @Value($$"${notify.templates.official-visit-created:}") private val officialVisitCreatedTemplateId: String,
+) {
   companion object {
     private val logger = LoggerFactory.getLogger(this::class.java)
   }
@@ -26,5 +31,9 @@ class GovNotifyConfiguration(@Value($$"${notify.api.key:}") private val apiKey: 
   }
 
   @Bean
-  fun emailTemplates() = EmailTemplates(emptySet())
+  fun emailTemplates() = EmailTemplates(
+    setOfNotNull(
+      officialVisitCreatedTemplateId.takeIf { it.isNotBlank() }?.let { EmailTemplate(it, OFFICIAL_VISIT_CREATED) },
+    ),
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/LocalRequestContextConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/LocalRequestContextConfiguration.kt
@@ -27,6 +27,7 @@ class LocalRequestContextConfiguration(private val localRequestContextIntercepto
       .addPathPatterns(
         "/official-visit/**",
         "/admin/**",
+        "/notification/**",
       )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
@@ -1,16 +1,30 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications
 
+import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationRecipient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.LocationsService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.Email
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.OfficialVisitCreatedEmail
 import java.time.LocalDateTime
 
 @Component
 class NotificationsFacade(
+  private val officialVisitRepository: OfficialVisitRepository,
+  private val locationsService: LocationsService,
+  private val prisonerSearchClient: PrisonerSearchClient,
   private val emailService: EmailService,
   private val notificationRepository: NotificationRepository,
 ) {
@@ -19,20 +33,75 @@ class NotificationsFacade(
   }
 
   @Transactional
-  fun sendOfficialVisitEmail(officialVisitId: Long, email: Email) {
+  fun sendNotification(officialVisitId: Long, request: NotificationRequest, user: User): NotificationResponse = run {
+    val officialVisit = officialVisitRepository.findById(officialVisitId)
+      .orElseThrow { EntityNotFoundException("Official visit with id $officialVisitId not found") }
+
+    val location = locationsService.getLocationById(officialVisit.dpsLocationId)?.localName ?: "Unknown location"
+    val prisoner = prisonerSearchClient.getPrisoner(officialVisit.prisonerNumber) ?: throw EntityNotFoundException("Prisoner not found ${officialVisit.prisonerNumber}")
+
+    val recipients = buildSet {
+      request.emailAddresses.distinct().forEach { emailAddress ->
+        sendOfficialVisitEmail(
+          officialVisit.officialVisitId,
+          getEmail(request.notificationType!!, officialVisit, emailAddress, prisoner, location, user),
+        )?.let { notificationId -> add(NotificationRecipient(emailAddress, notificationId)) }
+      }
+    }
+
+    NotificationResponse(officialVisitId, request.notificationType!!, recipients.toList())
+  }
+
+  /**
+   * Will return the identifier of the notification created if successful, otherwise null.
+   */
+  @Transactional
+  fun sendOfficialVisitEmail(officialVisitId: Long, email: Email): Long? = run {
+    var notificationId: Long? = null
+
     emailService.send(email)
-      .onSuccess { (notificationId, templateId) ->
+      .onSuccess { (govNotifyNotificationId, templateId) ->
         notificationRepository.saveAndFlush(
           NotificationEntity(
             officialVisitId = officialVisitId,
             templateId = templateId,
             emailAddress = email.emailAddress,
             reason = email.type().name,
-            govNotifyNotificationId = notificationId,
+            govNotifyNotificationId = govNotifyNotificationId,
             createdTime = LocalDateTime.now(),
-          ),
+          ).also { notificationId = it.notificationId },
         )
       }
       .onFailure { exception -> logger.info("Failed to send email ${email.type()}.", exception) }
+
+    notificationId
   }
+
+  private fun getEmail(
+    notificationType: NotificationType,
+    officialVisit: OfficialVisitEntity,
+    emailAddress: String,
+    prisoner: Prisoner,
+    location: String,
+    user: User,
+  ): Email = run {
+    when (notificationType) {
+      NotificationType.CREATE -> OfficialVisitCreatedEmail(
+        emailAddress = emailAddress,
+        prisonerName = prisoner.firstName + " " + prisoner.lastName,
+        appointmentDate = officialVisit.visitDate,
+        appointmentTime = officialVisit.startTime,
+        appointmentLocation = location,
+        userName = user.name,
+      )
+
+      else -> throw IllegalArgumentException("Unknown notification type $notificationType")
+    }
+  }
+}
+
+enum class NotificationType {
+  CREATE,
+  AMEND,
+  CANCEL,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/NotificationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/NotificationRequest.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationType
+
+data class NotificationRequest(
+  @Schema(description = "The type of notification to send", example = "CREATE")
+  @field:NotNull(message = "The email type is mandatory")
+  val notificationType: NotificationType?,
+
+  @Schema(description = "The recipient email address to send the notification to")
+  @field:NotEmpty(message = "The email address is mandatory")
+  val emailAddresses: List<
+    @NotBlank(message = "Email addresses must not be blank")
+    @Email(message = "Email addresses must be valid email addresses")
+    @Size(max = 100, message = "Email addresses must not exceed {max} characters")
+    String,
+    > = emptyList(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/NotificationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/NotificationResponse.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationType
+
+data class NotificationResponse(
+  @Schema(description = "The official visit id", example = "1")
+  val officialVisitId: Long,
+
+  @Schema(description = "The type of notification that was sent", example = "CREATE")
+  val notificationType: NotificationType,
+
+  @Schema(description = "The recipients the notification was sent to")
+  val recipients: List<NotificationRecipient>,
+)
+
+data class NotificationRecipient(val emailAddress: String, val notificationId: Long)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/NotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/NotificationsController.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.ErrorResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.config.getLocalRequestContext
+import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationsFacade
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+
+@Tag(name = "Notifications")
+@RestController
+@RequestMapping(value = ["notification"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@AuthApiResponses
+class NotificationsController(private val notificationFacade: NotificationsFacade) {
+
+  @Operation(summary = "Endpoint to support the sending of notifications for official visits.")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "201",
+        description = "The response containing the details of all notifications sent",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = NotificationResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No official visit found to send the notification for.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PostMapping(path = ["/{officialVisitId}"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @ResponseStatus(HttpStatus.CREATED)
+  @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__RW')")
+  fun sendNotification(
+    @PathVariable @Parameter(
+      name = "officialVisitId",
+      description = "The identifier of the official visit to send the notification for.",
+      example = "1",
+      required = true,
+    ) officialVisitId: Long,
+    @Valid
+    @RequestBody
+    @Parameter(description = "The request containing the details of the notification", required = true)
+    request: NotificationRequest,
+    httpRequest: HttpServletRequest,
+  ) = notificationFacade.sendNotification(officialVisitId, request, httpRequest.getLocalRequestContext().user)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/emails/EmailService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/emails/EmailService.kt
@@ -1,5 +1,9 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails
 
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toMediumFormatStyle
+import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 
 typealias NotificationId = UUID
@@ -28,5 +32,24 @@ class EmailTemplates(private val templates: Set<EmailTemplate>) {
 data class EmailTemplate(val templateId: TemplateId, val emailType: EmailType)
 
 enum class EmailType {
-  PLACEHOLDER_EMAIL_TYPE,
+  OFFICIAL_VISIT_CREATED,
+}
+
+class OfficialVisitCreatedEmail(
+  emailAddress: String,
+  prisonerName: String,
+  appointmentDate: LocalDate,
+  appointmentTime: LocalTime,
+  appointmentLocation: String,
+  userName: String,
+) : Email(emailAddress) {
+  init {
+    addPersonalisation("prisoner_name", prisonerName)
+    addPersonalisation("appointment_date", appointmentDate.toMediumFormatStyle())
+    addPersonalisation("appointment_time", appointmentTime.toHourMinuteStyle())
+    addPersonalisation("appointment_location", appointmentLocation)
+    addPersonalisation("user_name", userName)
+  }
+
+  override fun type(): EmailType = EmailType.OFFICIAL_VISIT_CREATED
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,3 +137,7 @@ springdoc:
     enabled: false
   api-docs:
     enabled: false
+
+notify:
+  templates:
+    official-visit-created: 99292100-5858-4b08-8e20-101e8df708de

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacadeTest.kt
@@ -3,23 +3,43 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toHourMinuteStyle
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toMediumFormatStyle
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsEntriesExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isInstanceOf
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.LocationsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.Email
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.OfficialVisitCreatedEmail
+import java.util.Optional
 import java.util.UUID
 
 class NotificationsFacadeTest {
   private val notificationId = UUID.randomUUID()
+  private val locationsService: LocationsService = mock()
+  private val prisonerSearchClient: PrisonerSearchClient = mock()
   private val emailService: EmailService = mock()
+  private val officialVisitRepository: OfficialVisitRepository = mock()
   private val notificationRepository: NotificationRepository = mock()
-  private val facade = NotificationsFacade(emailService, notificationRepository)
+  private val facade = NotificationsFacade(officialVisitRepository, locationsService, prisonerSearchClient, emailService, notificationRepository)
 
   @Test
   fun `should delegate to email service and save notification`() {
@@ -43,7 +63,53 @@ class NotificationsFacadeTest {
     verifyNoInteractions(notificationRepository)
   }
 
+  @Test
+  fun `should send create email via email service`() {
+    whenever { emailService.send(any()) } doReturn Result.success(notificationId to "fake template id")
+
+    val officialVisit = createAVisitEntity(1)
+    val prisoner = prisonerSearchPrisoner(
+      prisonerNumber = MOORLAND_PRISONER.number,
+      prisonCode = MOORLAND_PRISONER.prison,
+      bookingId = MOORLAND_PRISONER.bookingId,
+    )
+
+    whenever { officialVisitRepository.findById(1) } doReturn Optional.of(officialVisit)
+    whenever { locationsService.getLocationById(officialVisit.dpsLocationId) } doReturn moorlandLocation
+    whenever { prisonerSearchClient.getPrisoner(officialVisit.prisonerNumber) } doReturn prisoner
+
+    facade.sendNotification(
+      officialVisitId = 1,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email@address"),
+      ),
+      user = MOORLAND_PRISON_USER,
+    )
+
+    val emailCaptor = argumentCaptor<Email>()
+
+    inOrder(officialVisitRepository, locationsService, prisonerSearchClient, emailService, notificationRepository) {
+      verify(officialVisitRepository).findById(1)
+      verify(locationsService).getLocationById(officialVisit.dpsLocationId)
+      verify(prisonerSearchClient).getPrisoner(officialVisit.prisonerNumber)
+      verify(emailService).send(emailCaptor.capture())
+      verify(notificationRepository).saveAndFlush(any<NotificationEntity>())
+    }
+
+    val email = emailCaptor.firstValue
+    email isInstanceOf OfficialVisitCreatedEmail::class.java
+    email.emailAddress isEqualTo "email@address"
+    email.personalisation() containsEntriesExactlyInAnyOrder mapOf(
+      "appointment_date" to officialVisit.visitDate.toMediumFormatStyle(),
+      "appointment_location" to moorlandLocation.localName,
+      "appointment_time" to officialVisit.startTime.toHourMinuteStyle(),
+      "prisoner_name" to prisoner.firstName + " " + prisoner.lastName,
+      "user_name" to MOORLAND_PRISON_USER.name,
+    )
+  }
+
   object FakeEmail : Email("email@address") {
-    override fun type() = EmailType.PLACEHOLDER_EMAIL_TYPE
+    override fun type() = EmailType.OFFICIAL_VISIT_CREATED
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
@@ -1,0 +1,95 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.integration.resource
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createOfficialVisitRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
+import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
+import java.util.UUID
+
+class NotificationsIntegrationTest : IntegrationTestBase() {
+
+  private val location = moorlandLocation.copy(id = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"))
+
+  private val officialVisitor = OfficialVisitor(
+    visitorTypeCode = VisitorType.CONTACT,
+    relationshipCode = "POM",
+    contactId = 123,
+    prisonerContactId = 456,
+    leadVisitor = true,
+    assistedVisit = false,
+    assistedNotes = "visitor notes",
+    visitorEquipment = VisitorEquipment("Bringing secure laptop"),
+  )
+
+  private val nextMondayAt9 = createOfficialVisitRequest(Moorland.MONDAY_9_TO_10_VISIT_SLOT, listOf(officialVisitor))
+
+  @BeforeEach
+  @Transactional
+  fun setupTest() {
+    clearAllVisitData()
+
+    locationsInsidePrisonApi().stubGetLocationById(location)
+    locationsInsidePrisonApi().stubGetOfficialVisitLocationsAtPrison(MOORLAND, locations = listOf(location))
+
+    // Stub a known contact
+    personalRelationshipsApi().stubAllContacts(
+      prisonerNumber = MOORLAND_PRISONER.number,
+      prisonerContacts = listOf(
+        prisonerContact(
+          prisonerNumber = MOORLAND_PRISONER.number,
+          type = "O",
+          contactId = officialVisitor.contactId!!,
+          prisonerContactId = officialVisitor.prisonerContactId!!,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun `should send single create visit notification`() {
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    val response = webTestClient.send(
+      officialVisitId = scheduledVisit.officialVisitId,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email@address.com"),
+      ),
+    )
+
+    with(response) {
+      officialVisitId isEqualTo scheduledVisit.officialVisitId
+      recipients.map { it.emailAddress }.single() isEqualTo "email@address.com"
+    }
+  }
+
+  private fun WebTestClient.send(officialVisitId: Long, request: NotificationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
+    .post()
+    .uri("/notification/$officialVisitId")
+    .bodyValue(request)
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
+    .exchange()
+    .expectStatus().isCreated
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody<NotificationResponse>()
+    .returnResult().responseBody!!
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/emails/GovNotifyEmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/emails/GovNotifyEmailServiceTest.kt
@@ -16,7 +16,7 @@ class GovNotifyEmailServiceTest {
   private val sendEmailResponse = mock<SendEmailResponse>()
   private val notificationId = UUID.randomUUID()
   private val notificationClient = mock<NotificationClient>()
-  private val service = GovNotifyEmailService(notificationClient, EmailTemplates(setOf(EmailTemplate("template_id", EmailType.PLACEHOLDER_EMAIL_TYPE))))
+  private val service = GovNotifyEmailService(notificationClient, EmailTemplates(setOf(EmailTemplate("template_id", EmailType.OFFICIAL_VISIT_CREATED))))
 
   @Test
   fun `should succeed to send of email`() {
@@ -34,6 +34,6 @@ class GovNotifyEmailServiceTest {
   }
 
   object FakeEmail : Email("email@address") {
-    override fun type() = EmailType.PLACEHOLDER_EMAIL_TYPE
+    override fun type() = EmailType.OFFICIAL_VISIT_CREATED
   }
 }


### PR DESCRIPTION
Endpoint supporting the sending of notifications (emails) via an API call instead of automatically via other journeys e.g. create.

In its first iteration it only supports CREATE visit notifications at present.