### PR TITLE
OV-607 fix notification id being added to the notification response.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
@@ -69,8 +69,8 @@ class NotificationsFacade(
             reason = email.type().name,
             govNotifyNotificationId = govNotifyNotificationId,
             createdTime = LocalDateTime.now(),
-          ).also { notificationId = it.notificationId },
-        )
+          ),
+        ).also { notificationId = it.notificationId }
       }
       .onFailure { exception -> logger.info("Failed to send email ${email.type()}.", exception) }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacadeTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
@@ -39,7 +40,14 @@ class NotificationsFacadeTest {
   private val emailService: EmailService = mock()
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val notificationRepository: NotificationRepository = mock()
+  private val notification: NotificationEntity = mock()
   private val facade = NotificationsFacade(officialVisitRepository, locationsService, prisonerSearchClient, emailService, notificationRepository)
+
+  @BeforeEach
+  fun beforeEach() {
+    whenever { notification.notificationId } doReturn 1
+    whenever { notificationRepository.saveAndFlush(any<NotificationEntity>()) } doReturn notification
+  }
 
   @Test
   fun `should delegate to email service and save notification`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/IntegrationTestBase.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.wiremock.Manag
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.wiremock.PersonalRelationshipsApiExtension
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.wiremock.PrisonerSearchApiExtension
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.AuditedEventRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitorRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonTimeSlotRepository
@@ -79,6 +80,9 @@ abstract class IntegrationTestBase {
   @Autowired
   protected lateinit var timeSlotRepository: PrisonTimeSlotRepository
 
+  @Autowired
+  protected lateinit var notificationRepository: NotificationRepository
+
   @BeforeEach
   fun `stub default users and prisoners and reset stubbed events`() {
     stubEvents.reset()
@@ -122,6 +126,7 @@ abstract class IntegrationTestBase {
     visitorEquipmentRepository.deleteAll()
     officialVisitorRepository.deleteAll()
     officialVisitRepository.deleteAll()
+    notificationRepository.deleteAll()
   }
 
   protected fun prisonerSearchApi() = PrisonerSearchApiExtension.server

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
@@ -11,15 +11,20 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactly
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createOfficialVisitRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.now
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationRecipient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
 import java.util.UUID
@@ -75,9 +80,40 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
       ),
     )
 
+    val notification = notificationRepository.findAll().single()
+
+    with(notification) {
+      officialVisitId isEqualTo scheduledVisit.officialVisitId
+      emailAddress isEqualTo "email@address.com"
+      templateId isEqualTo "fake_template_id"
+      reason isEqualTo "OFFICIAL_VISIT_CREATED"
+      createdTime isCloseTo now()
+    }
+
     with(response) {
       officialVisitId isEqualTo scheduledVisit.officialVisitId
-      recipients.map { it.emailAddress }.single() isEqualTo "email@address.com"
+      recipients containsExactly listOf(NotificationRecipient("email@address.com", notification.notificationId))
+    }
+  }
+
+  @Test
+  fun `should send multiple create visit notifications`() {
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    val response = webTestClient.send(
+      officialVisitId = scheduledVisit.officialVisitId,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email1@address.com", "email2s@address.com"),
+      ),
+    )
+
+    val notificationRecipients = notificationRepository.findAll().map { NotificationRecipient(it.emailAddress, it.notificationId) }
+    notificationRecipients.map { it.emailAddress } containsExactlyInAnyOrder listOf("email1@address.com", "email2s@address.com")
+
+    with(response) {
+      officialVisitId isEqualTo scheduledVisit.officialVisitId
+      recipients containsExactlyInAnyOrder notificationRecipients
     }
   }
 


### PR DESCRIPTION
This changes fixes a bug spotted during manual testing in dev.  The integration test has been expanded to cover this.

The notification ID being added to the response was being carried out in the wrong place in the code so was always 0.  Note this had no effect on the notification persisted, this was correct, it was just the response at fault.