### PR TITLE
OV-626 : Add check for existing visit slot by time slot and location ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/admin/UpdateVisitSlotRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/admin/UpdateVisitSlotRequest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.admin
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.PositiveOrZero
-import java.util.UUID
 
 @Schema(description = "Request to update capacities for a prison visit slot")
 data class UpdateVisitSlotRequest(
@@ -17,7 +16,4 @@ data class UpdateVisitSlotRequest(
   @Schema(description = "Maximum video sessions allowed in the visit slot")
   @field:PositiveOrZero
   val maxVideo: Int? = null,
-
-  @Schema(description = "The Official visit Location Id")
-  val dpsLocationId: UUID? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/PrisonVisitSlotRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/PrisonVisitSlotRepository.kt
@@ -3,11 +3,13 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.PrisonVisitSlotEntity
+import java.util.UUID
 
 @Repository
 interface PrisonVisitSlotRepository : JpaRepository<PrisonVisitSlotEntity, Long> {
 
   fun existsByPrisonTimeSlotId(prisonTimeSlotId: Long): Boolean
+  fun existsByPrisonTimeSlotIdAndDpsLocationId(prisonTimeSlotId: Long, dpsLocationId: UUID): Boolean
   fun findByPrisonTimeSlotId(prisonTimeSlotId: Long): List<PrisonVisitSlotEntity>
   fun findByPrisonTimeSlotIdIn(prisonTimeSlotId: List<Long>): List<PrisonVisitSlotEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonVisitSlot
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.LocationsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
 import java.time.LocalDateTime
+import java.util.UUID
 
 @Service
 @Transactional
@@ -38,6 +39,10 @@ class VisitSlotService(
   fun create(prisonTimeSlotId: Long, request: CreateVisitSlotRequest, user: User): VisitSlot {
     val timeSlotEntity = prisonTimeSlotRepository.findById(prisonTimeSlotId)
       .orElseThrow { EntityNotFoundException("Prison time slot with ID $prisonTimeSlotId was not found for visit slot") }
+
+    require(!visitSlotExistsFor(prisonTimeSlotId, request.dpsLocationId)) {
+      throw EntityInUseException("A visit slot for location ID ${request.dpsLocationId} already exists for this prison time slot.")
+    }
 
     val entity = PrisonVisitSlotEntity(
       prisonVisitSlotId = 0L,
@@ -102,4 +107,6 @@ class VisitSlotService(
   }
 
   private fun officialVisitsExistFor(prisonVisitSlotId: Long): Boolean = officialVisitRepository.existsByPrisonVisitSlotPrisonVisitSlotId(prisonVisitSlotId)
+
+  private fun visitSlotExistsFor(prisonTimeSlotId: Long, dpsLocationId: UUID): Boolean = prisonVisitSlotRepository.existsByPrisonTimeSlotIdAndDpsLocationId(prisonTimeSlotId, dpsLocationId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotService.kt
@@ -66,12 +66,12 @@ class VisitSlotService(
     val timeSlotEntity = prisonTimeSlotRepository.findById(visitSlotEntity.prisonTimeSlotId)
       .orElseThrow { EntityNotFoundException("Prison time slot with ID ${visitSlotEntity.prisonTimeSlotId} was not found for visit slot") }
 
-    // Only capacities may be changed; dpsLocationId and prisonTimeSlotId must remain the same
+    // Only capacities may be changed; dpsLocationId and prisonTimeSlotId remain unchanged.
     val changed = visitSlotEntity.copy(
       maxAdults = request.maxAdults,
       maxGroups = request.maxGroups,
       maxVideoSessions = request.maxVideo,
-      dpsLocationId = request.dpsLocationId ?: visitSlotEntity.dpsLocationId,
+      dpsLocationId = visitSlotEntity.dpsLocationId,
       updatedBy = user.username,
       updatedTime = LocalDateTime.now(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/admin/VisitSlotIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/admin/VisitSlotIntegrationTest.kt
@@ -243,6 +243,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
     assertThat(updated.maxAdults).isEqualTo(8)
     assertThat(updated.maxGroups).isEqualTo(4)
     assertThat(updated.maxVideo).isEqualTo(1)
+    assertThat(updated.dpsLocationId).isEqualTo(created.dpsLocationId)
 
     webTestClient.delete()
       .uri("/admin/visit-slot/id/{visitSlotId}", created.visitSlotId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/admin/VisitSlotIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/admin/VisitSlotIntegrationTest.kt
@@ -164,7 +164,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `should return valid response if get request has valid visit slot id`() {
-    val createRequest = createVisitSlotRequest()
+    val createRequest = createVisitSlotRequest(UUID.randomUUID())
 
     val created = webTestClient.post()
       .uri("/admin/time-slot/{prisonTimeSlotId}/visit-slot", 1)
@@ -201,7 +201,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `should create update and delete visit slot for admin role`() {
-    val createRequest = createVisitSlotRequest()
+    val createRequest = createVisitSlotRequest(UUID.randomUUID())
 
     val created = webTestClient.post()
       .uri("/admin/time-slot/{prisonTimeSlotId}/visit-slot", 1)
@@ -220,7 +220,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
       .returnResult().responseBody!!
 
     assertThat(created.prisonTimeSlotId).isEqualTo(1)
-    assertThat(created.dpsLocationId).isEqualTo(location.id)
+    assertThat(created.dpsLocationId).isEqualTo(createRequest.dpsLocationId)
 
     val updateRequest = updateVisitSlotRequest()
 
@@ -258,9 +258,44 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return conflict when creating duplicate location visit slot for same time slot`() {
+    val createRequest = createVisitSlotRequest(UUID.randomUUID())
+
+    webTestClient.post()
+      .uri("/admin/time-slot/{prisonTimeSlotId}/visit-slot", 1)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(
+        setAuthorisation(
+          username = MOORLAND_PRISON_USER.username,
+          roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN"),
+        ),
+      )
+      .bodyValue(createRequest)
+      .exchange()
+      .expectStatus().isOk
+
+    webTestClient.post()
+      .uri("/admin/time-slot/{prisonTimeSlotId}/visit-slot", 1)
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .headers(
+        setAuthorisation(
+          username = MOORLAND_PRISON_USER.username,
+          roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN"),
+        ),
+      )
+      .bodyValue(createRequest)
+      .exchange()
+      .expectStatus().isEqualTo(org.springframework.http.HttpStatus.CONFLICT)
+      .expectBody().jsonPath("$.userMessage")
+      .isEqualTo("A visit slot for location ID ${createRequest.dpsLocationId} already exists for this prison time slot.")
+  }
+
+  @Test
   fun `should not delete visit slot when official visits exist`() {
     // create slot
-    val createRequest = createVisitSlotRequest()
+    val createRequest = createVisitSlotRequest(UUID.randomUUID())
 
     val created = webTestClient.post()
       .uri("/admin/time-slot/{prisonTimeSlotId}/visit-slot", 1)
@@ -303,7 +338,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
           prisonCode = MOORLAND,
           locationKeySuffix = "1-1",
           localName = "Visit place",
-          id = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
+          id = created.dpsLocationId,
         ),
       ),
     )
@@ -353,5 +388,5 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
 
   private fun updateVisitSlotRequest(): UpdateVisitSlotRequest = UpdateVisitSlotRequest(maxAdults = 8, maxGroups = 4, maxVideo = 1)
 
-  private fun createVisitSlotRequest(): CreateVisitSlotRequest = CreateVisitSlotRequest(dpsLocationId = location.id, maxAdults = 10, maxGroups = 5, maxVideo = 2)
+  private fun createVisitSlotRequest(dpsLocationId: UUID = location.id): CreateVisitSlotRequest = CreateVisitSlotRequest(dpsLocationId = dpsLocationId, maxAdults = 10, maxGroups = 5, maxVideo = 2)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotServiceTest.kt
@@ -143,13 +143,12 @@ class VisitSlotServiceTest {
 
   @Test
   fun `should update a visit slot capacities and return it`() {
-    val dpsLocationId = UUID.randomUUID()
-    val request = UpdateVisitSlotRequest(maxAdults = 5, maxGroups = 3, maxVideo = 1, dpsLocationId = dpsLocationId)
+    val request = UpdateVisitSlotRequest(maxAdults = 5, maxGroups = 3, maxVideo = 1)
     val existing = prisonVisitSlotEntity()
     whenever(prisonVisitSlotRepository.findById(1L)).thenReturn(Optional.of(existing))
     whenever(prisonTimeSlotRepository.findById(1L)).thenReturn(Optional.of(prisonTimeSlotEntity()))
     whenever(prisonVisitSlotRepository.saveAndFlush(any<PrisonVisitSlotEntity>())).thenAnswer { it.arguments[0] }
-    whenever(locationsService.getLocationById(dpsLocationId)).thenReturn(moorlandLocation)
+    whenever(locationsService.getLocationById(existing.dpsLocationId)).thenReturn(moorlandLocation)
 
     val updated = service.update(1L, request, MOORLAND_PRISON_USER)
 
@@ -157,6 +156,7 @@ class VisitSlotServiceTest {
     verify(prisonVisitSlotRepository).saveAndFlush(visitSlotCaptor.capture())
 
     visitSlotCaptor.firstValue.assertWithResponse(updated)
+    assertThat(updated.dpsLocationId).isEqualTo(existing.dpsLocationId)
     verify(prisonVisitSlotRepository).findById(1L)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/VisitSlotServiceTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -122,6 +123,22 @@ class VisitSlotServiceTest {
 
     verify(prisonTimeSlotRepository).findById(1L)
     verifyNoMoreInteractions(prisonVisitSlotRepository)
+  }
+
+  @Test
+  fun `should fail to create a visit slot when location already exists for the time slot`() {
+    val request = CreateVisitSlotRequest(dpsLocationId = UUID.randomUUID(), maxAdults = 10, maxGroups = 5, maxVideo = 2)
+    whenever(prisonTimeSlotRepository.findById(1L)).thenReturn(Optional.of(prisonTimeSlotEntity()))
+    whenever(prisonVisitSlotRepository.existsByPrisonTimeSlotIdAndDpsLocationId(1L, request.dpsLocationId)).thenReturn(true)
+
+    val exception = assertThrows<EntityInUseException> {
+      service.create(1L, request, MOORLAND_PRISON_USER)
+    }
+
+    assertThat(exception.message).isEqualTo("A visit slot for location ID ${request.dpsLocationId} already exists for this prison time slot.")
+    verify(prisonTimeSlotRepository).findById(1L)
+    verify(prisonVisitSlotRepository).existsByPrisonTimeSlotIdAndDpsLocationId(1L, request.dpsLocationId)
+    verify(prisonVisitSlotRepository, never()).saveAndFlush(any<PrisonVisitSlotEntity>())
   }
 
   @Test


### PR DESCRIPTION
This pull request adds a validation to prevent creating duplicate visit slots for the same location and time slot combination. 