### PR TITLE
OV-636: Avoid sharing inactive locations to UI users for available slots.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/admin/PrisonTimeSlotFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/admin/PrisonTimeSlotFacade.kt
@@ -15,7 +15,9 @@ class PrisonTimeSlotFacade(
   private val outboundEventsService: OutboundEventsService,
 ) {
   fun getPrisonTimeSlotById(prisonTimeSlotId: Long) = prisonTimeSlotService.getPrisonTimeSlotById(prisonTimeSlotId)
+
   fun getPrisonTimeSlotSummaryById(prisonTimeSlotId: Long) = prisonTimeSlotService.getPrisonTimeSlotSummaryById(prisonTimeSlotId)
+
   fun createPrisonTimeSlot(request: CreateTimeSlotRequest, user: User) = prisonTimeSlotService.create(request, user).also {
     outboundEventsService.send(
       outboundEvent = OutboundEvent.TIME_SLOT_CREATED,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/PrisonTimeSlotService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/PrisonTimeSlotService.kt
@@ -54,7 +54,7 @@ class PrisonTimeSlotService(
 
     val visitSlots = prisonVisitSlotRepository.findByPrisonTimeSlotId(prisonTimeSlotId).toVisitSlotListModel(prisonCode)
 
-    val decoratedVisitSlots = decorateWithLocationDescription(prisonCode = prisonCode, slots = visitSlots)
+    val decoratedVisitSlots = matchWithLocationDataAndFilterUnusableSlots(prisonCode = prisonCode, slots = visitSlots)
 
     return TimeSlotSummaryItem(
       timeSlot = timeSlot,
@@ -134,7 +134,7 @@ class PrisonTimeSlotService(
           .toVisitSlotListModel(prisonCode)
       }
 
-    val decoratedVisitSlots = decorateWithLocationDescription(prisonCode = prisonCode, slots = visitSlots)
+    val decoratedVisitSlots = matchWithLocationDataAndFilterUnusableSlots(prisonCode = prisonCode, slots = visitSlots)
 
     val visitSlotByTimeSlotIds: Map<Long, List<VisitSlot>> = decoratedVisitSlots.groupBy { it.prisonTimeSlotId }
 
@@ -152,7 +152,7 @@ class PrisonTimeSlotService(
     )
   }
 
-  private fun decorateWithLocationDescription(prisonCode: String, slots: List<VisitSlot>): List<VisitSlot> {
+  private fun matchWithLocationDataAndFilterUnusableSlots(prisonCode: String, slots: List<VisitSlot>): List<VisitSlot> {
     // This gets the ACTIVE visit-enabled locations from the Locations In Prison API
     val activeVisitLocations = locationService.getOfficialVisitLocationsAtPrison(prisonCode)
 
@@ -170,25 +170,25 @@ class PrisonTimeSlotService(
         // Matching location - but it is inactive - mark it as such in the description
         slot.copy(
           locationDescription = "${location.localName} (inactive)",
-          locationMaxCapacity = getCapacityForVisitType(location),
+          locationMaxCapacity = getLocationCapacityForVisits(location),
           locationType = location.locationType.value,
         )
       } else {
         // This location is active and enabled for visits
         slot.copy(
           locationDescription = location.localName,
-          locationMaxCapacity = getCapacityForVisitType(location),
+          locationMaxCapacity = getLocationCapacityForVisits(location),
           locationType = location.locationType.value,
         )
       }
     }
 
-    return decorateHasVisits(decoratedSlots)
+    return checkIfThereAreVisitsAssociated(decoratedSlots)
   }
 
-  private fun decorateHasVisits(decoratedSlots: List<VisitSlot>): List<VisitSlot> = decoratedSlots.map { slot ->
+  private fun checkIfThereAreVisitsAssociated(decoratedSlots: List<VisitSlot>): List<VisitSlot> = decoratedSlots.map { slot ->
     slot.copy(hasVisit = officialVisitRepository.existsByPrisonVisitSlotPrisonVisitSlotId(slot.visitSlotId))
   }
 
-  private fun getCapacityForVisitType(location: Location): Int? = location.usage?.firstNotNullOfOrNull { dto -> if (dto.usageType.name == "VISIT") dto.capacity else null }
+  private fun getLocationCapacityForVisits(location: Location): Int? = location.usage?.firstNotNullOfOrNull { dto -> if (dto.usageType.name == "VISIT") dto.capacity else null }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/PrisonTimeSlotService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/PrisonTimeSlotService.kt
@@ -48,11 +48,14 @@ class PrisonTimeSlotService(
   fun getPrisonTimeSlotSummaryById(prisonTimeSlotId: Long): TimeSlotSummaryItem {
     val prisonTimeSlotEntity = prisonTimeSlotRepository.findById(prisonTimeSlotId)
       .orElseThrow { EntityNotFoundException("Prison time slot with ID $prisonTimeSlotId was not found") }
+
     val prisonCode = prisonTimeSlotEntity.prisonCode
     val timeSlot = prisonTimeSlotEntity.toModel()
-    val visitSlots = prisonVisitSlotRepository.findByPrisonTimeSlotId(prisonTimeSlotId)
-      .toVisitSlotListModel(prisonCode)
+
+    val visitSlots = prisonVisitSlotRepository.findByPrisonTimeSlotId(prisonTimeSlotId).toVisitSlotListModel(prisonCode)
+
     val decoratedVisitSlots = decorateWithLocationDescription(prisonCode = prisonCode, slots = visitSlots)
+
     return TimeSlotSummaryItem(
       timeSlot = timeSlot,
       visitSlots = decoratedVisitSlots,
@@ -95,7 +98,6 @@ class PrisonTimeSlotService(
   @Transactional
   fun delete(prisonTimeSlotId: Long): TimeSlot {
     val deleted = prisonTimeSlotRepository.findById(prisonTimeSlotId).orElseThrow { EntityNotFoundException("Prison time slot with ID $prisonTimeSlotId was not found") }
-    // check association with visit slot
     require(noVisitSlotsExistFor(prisonTimeSlotId)) {
       throw EntityInUseException("The prison time slot has one or more visit slots associated with it and cannot be deleted.")
     }
@@ -151,19 +153,28 @@ class PrisonTimeSlotService(
   }
 
   private fun decorateWithLocationDescription(prisonCode: String, slots: List<VisitSlot>): List<VisitSlot> {
+    // This gets the ACTIVE visit-enabled locations from the Locations In Prison API
     val activeVisitLocations = locationService.getOfficialVisitLocationsAtPrison(prisonCode)
+
+    // Create a map of the active visit-enabled locations by Location UUID
     val locationById = activeVisitLocations.associateBy { it.id }
-    val decoratedSlots = slots.map { slot ->
+
+    // There may be visit slots defined for locations which are not enabled for visits - filter these out
+    val decoratedSlots = slots.mapNotNull { slot ->
       val location = locationById[slot.dpsLocationId]
+
       if (location == null) {
-        slot.copy(locationDescription = "** unknown **")
+        // No matching location - filter from the results returned
+        null
       } else if (location.status == Location.Status.INACTIVE) {
+        // Matching location - but it is inactive - mark it as such in the description
         slot.copy(
           locationDescription = "${location.localName} (inactive)",
           locationMaxCapacity = getCapacityForVisitType(location),
           locationType = location.locationType.value,
         )
       } else {
+        // This location is active and enabled for visits
         slot.copy(
           locationDescription = location.localName,
           locationMaxCapacity = getCapacityForVisitType(location),
@@ -171,6 +182,7 @@ class PrisonTimeSlotService(
         )
       }
     }
+
     return decorateHasVisits(decoratedSlots)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotService.kt
@@ -27,30 +27,36 @@ class AvailableSlotService(
     require(toDate >= fromDate) { "The to date must be on or after the from date" }
 
     val availableSlots = getAvailableSlots(prisonCode, fromDate, videoOnly)
+
     val bookedSlots = visitBookedRepository.findCurrentVisitsBookedBy(prisonCode, fromDate, toDate).filterNot { it.officialVisitId == existingOfficialVisitId }
 
     val sortedSlots = AvailableSlotBuilder.builder(timeSource, fromDate, toDate) { bookedSlots.forEach(::add) }.build(availableSlots, videoOnly)
       .sortedWith(compareBy({ it.visitDate }, { it.startTime }))
 
-    decorateWithLocationDescription(prisonCode, sortedSlots)
+    matchWithLocationsDataAndFilterUnusableSlots(prisonCode, sortedSlots)
   }
 
+  // Some these slots may be marked as unusable in the Locations API data so these are filtered when matching locations
   private fun getAvailableSlots(prisonCode: String, fromDate: LocalDate, videoOnly: Boolean) = if (videoOnly) {
     availableSlotRepository.findAvailableVideoSlotsForPrison(prisonCode, fromDate)
   } else {
     availableSlotRepository.findAvailableSlotsForPrison(prisonCode, fromDate)
   }
 
-  private fun decorateWithLocationDescription(prisonCode: String, slots: List<AvailableSlot>): List<AvailableSlot> {
+  private fun matchWithLocationsDataAndFilterUnusableSlots(prisonCode: String, slots: List<AvailableSlot>): List<AvailableSlot> {
     val visitLocations = locationService.getOfficialVisitLocationsAtPrison(prisonCode)
 
-    val decoratedSlots = slots.map { slot ->
+    val decoratedSlots = slots.mapNotNull { slot ->
       val location = visitLocations.find { location -> location.id == slot.dpsLocationId }
+
       if (location == null) {
-        slot.copy(locationDescription = "** unknown **")
+        // Location is archived or no longer suitable for visits so filter it from the returned available slots
+        null
       } else if (location.status == Location.Status.INACTIVE) {
+        // Location is inactive - mark it as such
         slot.copy(locationDescription = "${location.localName} (inactive)")
       } else {
+        // Location is available for visits - in both OV visit slot and Location API data
         slot.copy(locationDescription = location.localName)
       }
     }
@@ -69,6 +75,9 @@ private class AvailableSlotBuilder private constructor(private val timeSource: T
 
   fun add(bookedSlot: VisitBookedEntity) {
     val key = DatedVisit(bookedSlot)
+
+    // TODO: Telephone visits should take 1 off the maxGroups capacity, but ignore the maxAdults limit
+    // TODO: Should we treat telephone visits like video visits and decrement the same capacities?
 
     when {
       bookedSlot.isVisitType(VisitType.IN_PERSON) || bookedSlot.isVisitType(VisitType.UNKNOWN) -> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/CreateOfficialVisitIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/CreateOfficialVisitIntegrationTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE_PRISON_
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.hasSize
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isCloseTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isNotEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.next
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.now
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
@@ -45,7 +45,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.VisitMetri
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.VisitorMetricInfo
 import java.time.DayOfWeek
 import java.time.LocalTime
-import java.util.UUID
 
 class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
   @MockitoBean
@@ -70,7 +69,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
     visitDate = visitDateInTheFuture,
     startTime = LocalTime.of(9, 0),
     endTime = LocalTime.of(10, 0),
-    dpsLocationId = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
+    dpsLocationId = moorlandLocation.id,
     visitTypeCode = VisitType.IN_PERSON,
     staffNotes = "private notes",
     prisonerNotes = "public notes",
@@ -83,7 +82,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
     startTime = LocalTime.of(11, 0),
     endTime = LocalTime.of(12, 0),
     prisonVisitSlotId = 9,
-    dpsLocationId = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
+    dpsLocationId = moorlandLocation.id,
   )
 
   @BeforeEach
@@ -92,7 +91,10 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
     clearAllVisitData()
     stubEvents.reset()
 
-    // Stub a known contact
+    // Stub location for visits at Moorland
+    locationsInsidePrisonApi().stubGetOfficialVisitLocationsAtPrison(MOORLAND, listOf(moorlandLocation))
+
+    // Stub contacts
     personalRelationshipsApi().stubAllContacts(
       prisonerNumber = MOORLAND_PRISONER.number,
       prisonerContacts = listOf(
@@ -159,10 +161,10 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
       prisonerNumber isEqualTo MOORLAND_PRISONER.number
       offenderBookId isEqualTo MOORLAND_PRISONER.bookingId
       prisonVisitSlot.prisonVisitSlotId isEqualTo 1
+      dpsLocationId isEqualTo moorlandLocation.id
       visitDate isEqualTo visitDateInTheFuture
       startTime isEqualTo LocalTime.of(9, 0)
       endTime isEqualTo LocalTime.of(10, 0)
-      dpsLocationId isNotEqualTo null
       visitTypeCode isEqualTo VisitType.IN_PERSON
       visitStatusCode isEqualTo VisitStatusType.SCHEDULED
       staffNotes isEqualTo "private notes"
@@ -242,7 +244,7 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
       visitDate isEqualTo visitDateInTheFuture
       startTime isEqualTo LocalTime.of(9, 0)
       endTime isEqualTo LocalTime.of(10, 0)
-      dpsLocationId isNotEqualTo null
+      dpsLocationId isEqualTo moorlandLocation.id
       visitTypeCode isEqualTo VisitType.IN_PERSON
       visitStatusCode isEqualTo VisitStatusType.SCHEDULED
       staffNotes isEqualTo "private notes"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/GetOfficialVisitByIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/GetOfficialVisitByIdIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.CONTACT_MOORLAND_PRISONER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
@@ -21,7 +22,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitDetails
-import java.util.UUID
 
 class GetOfficialVisitByIdIntegrationTest : IntegrationTestBase() {
 
@@ -43,7 +43,7 @@ class GetOfficialVisitByIdIntegrationTest : IntegrationTestBase() {
   fun setupTest() {
     clearAllVisitData()
 
-    // Stub a known contact
+    // Stub contacts
     personalRelationshipsApi().stubAllContacts(
       prisonerNumber = MOORLAND_PRISONER.number,
       prisonerContacts = listOf(
@@ -57,7 +57,10 @@ class GetOfficialVisitByIdIntegrationTest : IntegrationTestBase() {
     )
     personalRelationshipsApi().stubForContactById(CONTACT_MOORLAND_PRISONER, "contact@email.address")
     personalRelationshipsApi().stubReferenceGroup()
-    locationsInsidePrisonApi().stubGetLocationById(moorlandLocation.copy(id = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247")))
+
+    // Stub locations
+    locationsInsidePrisonApi().stubGetOfficialVisitLocationsAtPrison(MOORLAND, listOf(moorlandLocation))
+    locationsInsidePrisonApi().stubGetLocationById(moorlandLocation)
   }
 
   @AfterEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/ReconciliationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/ReconciliationIntegrationTest.kt
@@ -8,11 +8,14 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createOfficialVisitRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation2
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.today
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
@@ -34,6 +37,9 @@ class ReconciliationIntegrationTest : IntegrationTestBase() {
   @Transactional
   fun setupTest() {
     clearAllVisitData()
+
+    // Stub locations for visits at Moorland
+    locationsInsidePrisonApi().stubGetOfficialVisitLocationsAtPrison(MOORLAND, listOf(moorlandLocation, moorlandLocation2))
 
     // Stub a known contact
     personalRelationshipsApi().stubAllContacts(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncVisitSlotIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncVisitSlotIntegrationTest.kt
@@ -11,6 +11,7 @@ import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.next
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.today
@@ -33,7 +34,6 @@ import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.temporal.ChronoUnit
-import java.util.UUID
 
 class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
   private var savedPrisonVisitSlotId = 0L
@@ -60,7 +60,7 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
     visitDate = visitDateInTheFuture,
     startTime = LocalTime.of(9, 0),
     endTime = LocalTime.of(10, 0),
-    dpsLocationId = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
+    dpsLocationId = moorlandLocation.id,
     visitTypeCode = VisitType.IN_PERSON,
     staffNotes = "private notes",
     prisonerNotes = "public notes",
@@ -70,7 +70,11 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
 
   @BeforeEach
   fun initialiseData() {
+    // Needed for the visit create used in testing
+    locationsInsidePrisonApi().stubGetOfficialVisitLocationsAtPrison(MOORLAND, listOf(moorlandLocation))
+
     savedPrisonVisitSlotId = (webTestClient.createVisitSlot()).visitSlotId
+
     stubEvents.reset()
   }
 
@@ -212,14 +216,14 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
 
   private fun createVisitSlotRequest() = SyncCreateVisitSlotRequest(
     prisonTimeSlotId = 1L,
-    dpsLocationId = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
+    dpsLocationId = moorlandLocation.id,
     maxAdults = 10,
     createdBy = "NOMIS-CREATE-USER",
     createdTime = createdTime,
   )
 
   private fun updateVisitSlotRequest() = SyncUpdateVisitSlotRequest(
-    dpsLocationId = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"),
+    dpsLocationId = moorlandLocation.id,
     updatedBy = "NOMIS-UPDATE-USER",
     maxAdults = 15,
     updatedTime = updatedTime,
@@ -247,6 +251,6 @@ class SyncVisitSlotIntegrationTest : IntegrationTestBase() {
     .exchange()
     .expectStatus().isCreated
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(CreateOfficialVisitResponse::class.java)
+    .expectBody<CreateOfficialVisitResponse>()
     .returnResult().responseBody!!
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/PrisonTimeSlotServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/admin/PrisonTimeSlotServiceTest.kt
@@ -509,7 +509,7 @@ class PrisonTimeSlotServiceTest {
   }
 
   @Test
-  fun `should mark visit slot location as unknown when location missing from official list`() {
+  fun `should ignore visit slots where they are missing from the location list`() {
     val timeSlotEntity = PrisonTimeSlotEntity(
       prisonTimeSlotId = 1L,
       prisonCode = MOORLAND_PRISONER.prison,
@@ -534,8 +534,6 @@ class PrisonTimeSlotServiceTest {
     whenever(prisonTimeSlotRepository.findAllByPrisonCodeWithExpiryDateAfterCutOffDate(MOORLAND_PRISONER.prison, LocalDate.now().minusDays(7))).thenReturn(listOf(timeSlotEntity))
     whenever(prisonVisitSlotRepository.findByPrisonTimeSlotIdIn(listOf(timeSlotEntity.prisonTimeSlotId))).thenReturn(listOf(visitSlotEntity))
     whenever(prisonerSearchClient.findPrisonName(MOORLAND_PRISONER.prison)).thenReturn("A prison")
-
-    // official locations do not include the dpsLocationId used by the visit slot
     whenever(locationService.getOfficialVisitLocationsAtPrison(MOORLAND_PRISONER.prison)).thenReturn(emptyList())
 
     val summary = prisonTimeSlotService.getAllPrisonTimeSlotsAndAssociatedVisitSlots(MOORLAND_PRISONER.prison, true)
@@ -546,12 +544,8 @@ class PrisonTimeSlotServiceTest {
         prisonName = "A prison",
         timeSlots = listOf(
           TimeSlotSummaryItem(
-            timeSlotEntity.toTimeSlotModel(),
-            listOf(
-              visitSlotEntity.toVisitSlotModel(MOORLAND_PRISONER.prison).copy(
-                locationDescription = "** unknown **",
-              ),
-            ),
+            timeSlot = timeSlotEntity.toTimeSlotModel(),
+            visitSlots = emptyList(),
           ),
         ),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotServiceTest.kt
@@ -33,13 +33,26 @@ class AvailableSlotServiceTest {
   private val locationsService: LocationsService = Mockito.mock()
   private lateinit var availableSlotService: AvailableSlotService
 
+  // Tests used a fixed location ID to match with mocked responses
+  private val locationId = UUID.randomUUID()
+
+  @BeforeEach
+  fun setup() {
+    locationsService.stub {
+      on {
+        getOfficialVisitLocationsAtPrison(eq(MOORLAND))
+      } doReturn officialVisitLocations()
+    }
+  }
+
   @Nested
   inner class BadDates {
     @BeforeEach
     fun beforeEach() {
       availableSlotService = service(LocalDateTime.now())
 
-      // This is only used to decorate available slots with location descriptions
+      // This is used to decorate available slots with location descriptions
+      // AND to filter any inactive locations or those no longer configured for official visits
       locationsService.stub {
         on {
           getOfficialVisitLocationsAtPrison(eq(MOORLAND))
@@ -221,6 +234,7 @@ class AvailableSlotServiceTest {
     @BeforeEach
     fun beforeEach() {
       availableSlotService = service(mondayAtMidday)
+
       availableSlotRepository.stub {
         on {
           findAvailableSlotsForPrison(
@@ -229,6 +243,7 @@ class AvailableSlotServiceTest {
           )
         } doReturn availableSlots
       }
+
       visitBookedRepository.stub {
         on {
           findCurrentVisitsBookedBy(
@@ -363,6 +378,7 @@ class AvailableSlotServiceTest {
     @BeforeEach
     fun beforeEach() {
       availableSlotService = service(mondayAtMidday)
+
       availableSlotRepository.stub {
         on {
           findAvailableVideoSlotsForPrison(
@@ -371,6 +387,7 @@ class AvailableSlotServiceTest {
           )
         } doReturn availableSlots
       }
+
       visitBookedRepository.stub {
         on {
           findCurrentVisitsBookedBy(
@@ -488,6 +505,7 @@ class AvailableSlotServiceTest {
     @BeforeEach
     fun beforeEach() {
       availableSlotService = service(mondayAtEightAm)
+
       availableSlotRepository.stub {
         on {
           findAvailableVideoSlotsForPrison(
@@ -496,6 +514,7 @@ class AvailableSlotServiceTest {
           )
         } doReturn availableSlots
       }
+
       visitBookedRepository.stub {
         on {
           findCurrentVisitsBookedBy(
@@ -653,6 +672,7 @@ class AvailableSlotServiceTest {
     @BeforeEach
     fun beforeEach() {
       availableSlotService = service(mondayAtMidday)
+
       availableSlotRepository.stub {
         on {
           findAvailableSlotsForPrison(
@@ -661,6 +681,7 @@ class AvailableSlotServiceTest {
           )
         } doReturn availableSlots
       }
+
       visitBookedRepository.stub {
         on {
           findCurrentVisitsBookedBy(
@@ -722,6 +743,59 @@ class AvailableSlotServiceTest {
     }
   }
 
+  @Nested
+  @DisplayName("Available slots do not show for inactive or non-existent locations")
+  inner class AvailableSlotsNotActiveInLocations {
+    private val mondayAtMidday = LocalDate.of(2025, 11, 17).atTime(12, 0)
+    private val availableSlots: MutableList<AvailableSlotEntity> = mutableListOf()
+    private val bookedSlots: MutableList<VisitBookedEntity> = mutableListOf()
+
+    @BeforeEach
+    fun beforeEach() {
+      availableSlotService = service(mondayAtMidday)
+
+      locationsService.stub {
+        on {
+          getOfficialVisitLocationsAtPrison(eq(MOORLAND))
+        } doReturn emptyList()
+      }
+
+      availableSlotRepository.stub {
+        on {
+          findAvailableSlotsForPrison(
+            MOORLAND,
+            mondayAtMidday.toLocalDate(),
+          )
+        } doReturn availableSlots
+      }
+
+      visitBookedRepository.stub {
+        on {
+          findCurrentVisitsBookedBy(
+            eq(MOORLAND),
+            eq(mondayAtMidday.toLocalDate()),
+            any(),
+          )
+        } doReturn bookedSlots
+      }
+    }
+
+    @Test
+    fun `should not offer any available slots when the location ID is not found in the location API visit locations`() {
+      availableSlots.add(availableSlot(Day.MON, 14, 5, 2, effectiveDate = mondayAtMidday.toLocalDate()))
+
+      val freeSlots =
+        availableSlotService.getAvailableSlotsForPrison(
+          MOORLAND,
+          mondayAtMidday.toLocalDate(),
+          mondayAtMidday.toLocalDate().plusDays(1),
+          false,
+        )
+
+      freeSlots.size isEqualTo 0
+    }
+  }
+
   private fun service(dateTime: LocalDateTime) = AvailableSlotService(
     { dateTime },
     visitBookedRepository,
@@ -748,7 +822,7 @@ class AvailableSlotServiceTest {
     endTime = LocalTime.of(startHour, 59),
     effectiveDate = effectiveDate,
     expiryDate = expiryDate,
-    dpsLocationId = UUID.randomUUID(),
+    dpsLocationId = locationId,
     maxAdults = maxAdults,
     maxGroups = maxGroups,
     maxVideoSessions = maxVideo,
@@ -779,13 +853,13 @@ class AvailableSlotServiceTest {
       relationshipCode = "--",
       firstName = "first name",
       lastName = "last name",
-      dpsLocationId = UUID.randomUUID(),
+      dpsLocationId = locationId,
     )
   }
 
   private fun officialVisitLocations() = listOf(
     Location(
-      id = UUID.randomUUID(),
+      id = locationId,
       prisonId = MOORLAND,
       localName = "A name",
       code = "Code",


### PR DESCRIPTION
This PR introduces a shift in rules so that even if visit slots are setup, they will be filtered from UI and client views if the Locations in Prison API does not think the locations are suitable for official visits. 

It implements the rules described in this diagram.

<img width="1041" height="803" alt="Checks-using-locations-API" src="https://github.com/user-attachments/assets/b0cba1c5-b53d-4d2f-b10d-76bbead2b2b7" />

The important point in this is that migration, sync and reconcile do not care what the Locations API thinks, and doesn't check - for these, they trust what NOMIS provides, and will report them back if the visit slots exist in the DPS database.

The Locations in Prison API only reports the state of locations as they exist today - but some visit slots that are still active were created in 2009 ... 2016 - and reflect a different picture. 
