### PR TITLE
OV-661: Get official visit by ID (with no prison code)

### DIFF
--- a/scripts/rollout-control.sh
+++ b/scripts/rollout-control.sh
@@ -19,9 +19,15 @@ menu_function() {
   echo " 5 - Add a prison"
   echo " 6 - Remove a prison"
   echo ""
-  echo " 7 - Toggle two month calendar feature"
+  echo "Prisons which see a warning for pending NOMIS screen switch-off"
   echo ""
-  echo " 9 - Restart services for changes to take effect"
+  echo " 7 - Replace with a new list"
+  echo " 8 - Add a prison"
+  echo " 9 - Remove a prison"
+  echo ""
+  echo " 10 - Toggle two month calendar feature"
+  echo ""
+  echo " 11 - Restart services for changes to take effect"
   echo ""
   echo " 0 - Exit"
   echo "----------------------------"
@@ -36,15 +42,17 @@ show_current() {
   FEATURE_ALLOW_SOCIAL_VISITORS_PRISONS=$(kubectl -n "$NAMESPACE" get secret feature-toggles -o jsonpath='{.data.FEATURE_ALLOW_SOCIAL_VISITORS_PRISONS}' | base64 -d)
   FEATURE_DPS_ENABLED_PRISONS=$(kubectl -n "$NAMESPACE" get secret feature-toggles -o jsonpath='{.data.FEATURE_DPS_ENABLED_PRISONS}' | base64 -d)
   FEATURE_TWO_MONTH_CALENDAR_ENABLED=$(kubectl -n "$NAMESPACE" get secret feature-toggles -o jsonpath='{.data.FEATURE_TWO_MONTH_CALENDAR_ENABLED}' | base64 -d)
+  FEATURE_NOMIS_SWITCH_OFF_PRISONS=$(kubectl -n "$NAMESPACE" get secret feature-toggles -o jsonpath='{.data.FEATURE_NOMIS_SWITCH_OFF_PRISONS}' | base64 -d)
   NOTIFY_API_KEY=$(kubectl -n "$NAMESPACE" get secret hmpps-official-visits-gov-notify-creds -o jsonpath='{.data.NOTIFY_API_KEY}' | base64 -d)
 
   clear
   echo "-------------------------------------------------------------------------------------"
-  echo "Environment                 : $ENV"
-  echo "Social visitors allowed in  : $FEATURE_ALLOW_SOCIAL_VISITORS_PRISONS"
-  echo "DPS visits enabled in       : $FEATURE_DPS_ENABLED_PRISONS"
-  echo "Notify API key              : ${NOTIFY_API_KEY:-Missing}"
-  echo "Two month calendar enabled  : ${FEATURE_TWO_MONTH_CALENDAR_ENABLED:-false}"
+  echo "Environment                   : $ENV"
+  echo "Social visitors allowed in    : $FEATURE_ALLOW_SOCIAL_VISITORS_PRISONS"
+  echo "DPS visits enabled in         : $FEATURE_DPS_ENABLED_PRISONS"
+  echo "Notify API key                : ${NOTIFY_API_KEY:-Missing}"
+  echo "Two month calendar enabled    : ${FEATURE_TWO_MONTH_CALENDAR_ENABLED:-false}"
+  echo "Warn NOMIS switch off prisons : ${FEATURE_NOMIS_SWITCH_OFF_PRISONS}"
 }
 
 add_dps_enabled_prison() {
@@ -99,6 +107,34 @@ remove_prison_from_social_allowed_prisons() {
   NEW=$(echo ",$CURRENT," | sed "s/,$prison,/,/g; s/^,//; s/,$//")
   echo "Applying new value : $NEW"
   stringData="{\"stringData\":{\"FEATURE_ALLOW_SOCIAL_VISITORS_PRISONS\":\"$NEW\"}}"
+  kubectl -n "$2" patch secret feature-toggles -p $stringData
+}
+
+add_nomis_switch_off_prison() {
+  echo "Adding $3 to NOMIS switch off prisons in $1 namespace $2"
+  CURRENT=$(kubectl -n "$2" get secret feature-toggles -o jsonpath='{.data.FEATURE_NOMIS_SWITCH_OFF_PRISONS}' | base64 -d)
+  NEW="$CURRENT,$3"
+  echo "Applying new value : $NEW"
+  stringData="{\"stringData\":{\"FEATURE_NOMIS_SWITCH_OFF_PRISONS\":\"$NEW\"}}"
+  kubectl -n "$2" patch secret feature-toggles -p $stringData
+}
+
+add_list_nomis_switch_off_prisons() {
+  echo "Replace existing list with $3 for NOMIS switch off prisons in $1 namespace $2"
+  CURRENT=$(kubectl -n "$2" get secret feature-toggles -o jsonpath='{.data.FEATURE_NOMIS_SWITCH_OFF_PRISONS}' | base64 -d)
+  NEW=$3
+  echo "Applying new value : $NEW"
+  stringData="{\"stringData\":{\"FEATURE_NOMIS_SWITCH_OFF_PRISONS\":\"$NEW\"}}"
+  kubectl -n "$2" patch secret feature-toggles -p $stringData
+}
+
+remove_prison_from_nomis_switch_off_prisons() {
+  echo "Removing prison $3 from NOMIS switch off prisons in $1 namespace $2"
+  prison=$3
+  CURRENT=$(kubectl -n "$2" get secret feature-toggles -o jsonpath='{.data.FEATURE_NOMIS_SWITCH_OFF_PRISONS}' | base64 -d)
+  NEW=$(echo ",$CURRENT," | sed "s/,$prison,/,/g; s/^,//; s/,$//")
+  echo "Applying new value : $NEW"
+  stringData="{\"stringData\":{\"FEATURE_NOMIS_SWITCH_OFF_PRISONS\":\"$NEW\"}}"
   kubectl -n "$2" patch secret feature-toggles -p $stringData
 }
 
@@ -166,13 +202,29 @@ while true; do
           read -p "Enter a prison code to remove : " prison
           remove_prison_from_social_allowed_prisons "$ENV" "$NAMESPACE" "$prison"
           ;;
-      
+
       7)
+          echo "Replace the list of prisons which warn of NOMIS screen switch off"
+          read -p "Enter a comma-separated list of prison to replace the current list : " prison_list
+          add_list_nomis_switch_off_prisons "$ENV" "$NAMESPACE" "$prison_list"
+          ;;
+      8)
+          echo "Add a prison to the list which warn of NOMIS screen switch off"
+          read -p "Enter a prison code to add : " prison
+          add_nomis_switch_off_prison "$ENV" "$NAMESPACE" "$prison"
+          ;;
+       9)
+          echo "Remove a prison from the list which warn of NOMIS screen switch off"
+          read -p "Enter a prison code to remove : " prison
+          remove_prison_from_nomis_switch_off_prisons "$ENV" "$NAMESPACE" "$prison"
+          ;;
+
+      10)
           echo "Toggle two month calendar - currently ${FEATURE_TWO_MONTH_CALENDAR_ENABLED:-false}"
           toggle_two_month_calendar "$ENV" "$NAMESPACE" "${FEATURE_TWO_MONTH_CALENDAR_ENABLED:-false}"
           ;;
 
-      9)  echo "Restarting services"
+      11)  echo "Restarting services"
           restart_services "$ENV" "$NAMESPACE"
           ;;
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/OfficialVisitsApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/OfficialVisitsApiExceptionHandler.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.exception.DuplicateOffende
 import uk.gov.justice.digital.hmpps.officialvisitsapi.exception.DuplicateOffenderVisitIdErrorResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.exception.EntityInUseException
 import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.CaseloadAccessException
+import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.CaseloadAccessHiddenException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 @RestControllerAdvice
@@ -99,6 +100,20 @@ class OfficialVisitsApiExceptionHandler {
       .body(
         ErrorResponse(
           status = CONFLICT.value(),
+          userMessage = e.message,
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(CaseloadAccessHiddenException::class)
+  fun handleCaseLoadAccessHiddenException(e: CaseloadAccessHiddenException): ResponseEntity<ErrorResponse> {
+    log.info("Case load access hidden exception: {}", e.message)
+    return ResponseEntity
+      .status(NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = NOT_FOUND.value(),
           userMessage = e.message,
           developerMessage = e.message,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
@@ -65,7 +65,16 @@ class OfficialVisitFacade(
     }
   }
 
-  fun getOfficialVisitByPrisonCodeAndId(prisonCode: String, officialVisitId: Long): OfficialVisitDetails = officialVisitsRetrievalService.getOfficialVisitByPrisonCodeAndId(prisonCode, officialVisitId)
+  fun getOfficialVisitByPrisonCodeAndId(prisonCode: String, officialVisitId: Long) = officialVisitsRetrievalService.getOfficialVisitByPrisonCodeAndId(prisonCode, officialVisitId)
+
+  open fun getOfficialVisitById(officialVisitId: Long, user: User): OfficialVisitDetails {
+    val visitAtPrison = officialVisitsRetrievalService.getPrisonCodeForOfficialVisitId(officialVisitId)
+    if (user is PrisonUser) {
+      // With the hiddenException option this will respond with 404 NotFound if the user does not have caseload access to the visit
+      checkPrisonUsersCaseloads(visitAtPrison, user, "The visit was not found or is restricted by caseload", hiddenException = true)
+    }
+    return officialVisitsRetrievalService.getOfficialVisitById(officialVisitId)
+  }
 
   fun searchForOfficialVisitSummaries(
     prisonCode: String,
@@ -224,11 +233,16 @@ class OfficialVisitFacade(
 
   fun findOverlappingScheduledVisits(prisonCode: String, request: OverlappingVisitsCriteriaRequest) = overlappingVisitsService.findOverlappingScheduledVisits(prisonCode, request)
 
-  private fun checkPrisonUsersCaseloads(prisonCode: String, user: PrisonUser, message: String) {
+  private fun checkPrisonUsersCaseloads(prisonCode: String, user: PrisonUser, message: String, hiddenException: Boolean = false) {
     if (!user.hasCaseloadAccess(prisonCode)) {
-      throw CaseloadAccessException(message)
+      if (hiddenException) {
+        throw CaseloadAccessHiddenException(message)
+      } else {
+        throw CaseloadAccessException(message)
+      }
     }
   }
 }
 
 class CaseloadAccessException(message: String) : RuntimeException(message)
+class CaseloadAccessHiddenException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/OfficialVisitRepository.kt
@@ -16,6 +16,8 @@ import java.time.LocalTime
 interface OfficialVisitRepository : JpaRepository<OfficialVisitEntity, Long> {
   fun findByOfficialVisitIdAndPrisonCode(officialVisitId: Long, prisonCode: String): OfficialVisitEntity?
 
+  fun findByOfficialVisitId(officialVisitId: Long): OfficialVisitEntity?
+
   @Query("SELECT ov.officialVisitId FROM OfficialVisitEntity ov WHERE (:currentTermOnly is null OR ov.currentTerm = :currentTermOnly)")
   fun findAllOfficialVisitIds(currentTermOnly: Boolean?, pageable: Pageable): Page<Long>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitController.kt
@@ -85,7 +85,7 @@ class OfficialVisitController(private val facade: OfficialVisitFacade) {
     value = [
       ApiResponse(
         responseCode = "200",
-        description = "Official visit found",
+        description = "Visit details",
         content = [
           Content(
             mediaType = "application/json",
@@ -95,7 +95,7 @@ class OfficialVisitController(private val facade: OfficialVisitFacade) {
       ),
       ApiResponse(
         responseCode = "404",
-        description = "No official visit found",
+        description = "Official visit not found",
         content = [Content(schema = Schema(implementation = ErrorResponse::class))],
       ),
     ],
@@ -115,6 +115,41 @@ class OfficialVisitController(private val facade: OfficialVisitFacade) {
       required = true,
     ) officialVisitId: Long,
   ): OfficialVisitDetails = facade.getOfficialVisitByPrisonCodeAndId(prisonCode, officialVisitId)
+
+  @GetMapping("/id/{officialVisitId}")
+  @Operation(
+    summary = "Get an official visit by official visit ID",
+    description = "Get the full details of an official visit, its visitors and prisoner details",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Visit details",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = OfficialVisitDetails::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Official visit not found",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__R', 'ROLE_OFFICIAL_VISITS_RW')")
+  fun getOfficialVisitById(
+    @PathVariable @Parameter(
+      name = "officialVisitId",
+      description = "The official visit ID",
+      example = "123456",
+      required = true,
+    ) officialVisitId: Long,
+    httpRequest: HttpServletRequest,
+  ): OfficialVisitDetails = facade.getOfficialVisitById(officialVisitId, httpRequest.getLocalRequestContext().user)
 
   @Operation(summary = "Endpoint to search for official visit summaries for given search criteria.")
   @PostMapping(path = ["/prison/{prisonCode}/find-by-criteria"], consumes = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitsRetrievalService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitsRetrievalService.kt
@@ -31,6 +31,27 @@ class OfficialVisitsRetrievalService(
 ) {
 
   @Transactional(readOnly = true)
+  fun getPrisonCodeForOfficialVisitId(id: Long): String {
+    val ov = officialVisitRepository.findByOfficialVisitId(id)
+      ?: throw EntityNotFoundException("Official visit with id $id was not found")
+    return ov.prisonCode
+  }
+
+  @Transactional(readOnly = true)
+  fun getOfficialVisitById(id: Long): OfficialVisitDetails {
+    val ove = officialVisitRepository.findByOfficialVisitId(id)
+      ?: throw EntityNotFoundException("Official visit with id $id was not found")
+
+    val prisoner = prisonerSearchClient.getPrisoner(ove.prisonerNumber)
+      ?: throw EntityNotFoundException("Prisoner not found ${ove.prisonerNumber}")
+
+    val pve = prisonerVisitedRepository.findByOfficialVisit(ove)
+      ?: throw EntityNotFoundException("Prisoner visited not found for visit ID $id")
+
+    return populateOfficialVisitDetails(ove, prisoner, pve)
+  }
+
+  @Transactional(readOnly = true)
   fun getOfficialVisitByPrisonCodeAndId(prisonCode: String, id: Long): OfficialVisitDetails {
     val ove = officialVisitRepository.findByOfficialVisitIdAndPrisonCode(id, prisonCode)
       ?: throw EntityNotFoundException("Official visit with id $id and prison code $prisonCode not found")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
@@ -113,10 +113,29 @@ class OfficialVisitFacadeTest {
   }
 
   @Test
-  fun `should delegate to service to fetch official visits based on Id`() {
+  fun `should delegate to service to fetch official visit by prison code and Id`() {
     facade.getOfficialVisitByPrisonCodeAndId(MOORLAND, 1L)
 
     verify(officialVisitsRetrievalService).getOfficialVisitByPrisonCodeAndId(MOORLAND, 1L)
+  }
+
+  @Test
+  fun `should delegate to service to fetch official visit by Id`() {
+    whenever(officialVisitsRetrievalService.getPrisonCodeForOfficialVisitId(1L)).thenReturn("MDI")
+
+    facade.getOfficialVisitById(1L, MOORLAND_PRISON_USER)
+
+    verify(officialVisitsRetrievalService).getOfficialVisitById(1L)
+  }
+
+  @Test
+  fun `should fail to get by ID with if user is not in the correct caseload`() {
+    whenever(officialVisitsRetrievalService.getPrisonCodeForOfficialVisitId(1L)).thenReturn("MDI")
+
+    assertThrows<CaseloadAccessHiddenException> {
+      facade.getOfficialVisitById(1, PENTONVILLE_PRISON_USER)
+    }
+      .message isEqualTo "The visit was not found or is restricted by caseload"
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitRetrievalIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitRetrievalIntegrationTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createOfficialVisitRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
@@ -23,7 +24,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisi
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitDetails
 
-class GetOfficialVisitByIdIntegrationTest : IntegrationTestBase() {
+class OfficialVisitRetrievalIntegrationTest : IntegrationTestBase() {
 
   private val officialVisitor = OfficialVisitor(
     visitorTypeCode = VisitorType.CONTACT,
@@ -70,11 +71,6 @@ class GetOfficialVisitByIdIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should error when the ID does not exist`() {
-    webTestClient.getOfficialVisitByInvalidPrisonAndId(MOORLAND_PRISONER.prison, 999L)
-  }
-
-  @Test
   fun `should get an official visit by prison code and ID`() {
     val response = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
@@ -105,14 +101,55 @@ class GetOfficialVisitByIdIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  private fun WebTestClient.getOfficialVisitByInvalidPrisonAndId(prisonCode: String, officialVisitId: Long) = this
-    .get()
-    .uri("/official-visit/prison/$prisonCode/id/$officialVisitId")
-    .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN"))).exchange()
-    .expectStatus().is4xxClientError
-    .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody().jsonPath("$.userMessage").isEqualTo("Official visit with id $officialVisitId and prison code $prisonCode not found")
+  @Test
+  fun `should error when the ID does not exist at the prison provided`() {
+    webTestClient.getOfficialVisitByInvalidPrisonAndId(MOORLAND_PRISONER.prison, 999L)
+  }
+
+  @Test
+  fun `should get an official visit by ID`() {
+    val response = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    val visitDetail = webTestClient.getOfficialVisitById(response.officialVisitId)
+
+    with(visitDetail) {
+      officialVisitId isEqualTo response.officialVisitId
+      prisonCode isEqualTo MOORLAND_PRISONER.prison
+      prisonerVisited?.prisonerNumber isEqualTo nextMondayAt9.prisonerNumber
+      dpsLocationId isEqualTo nextMondayAt9.dpsLocationId
+      locationDescription isEqualTo moorlandLocation.localName
+      visitTypeCode isEqualTo nextMondayAt9.visitTypeCode
+      visitStatus isEqualTo VisitStatusType.SCHEDULED
+      staffNotes isEqualTo nextMondayAt9.staffNotes
+      prisonerNotes isEqualTo nextMondayAt9.prisonerNotes
+      visitDate isEqualTo nextMondayAt9.visitDate
+      startTime isEqualTo nextMondayAt9.startTime
+      endTime isEqualTo nextMondayAt9.endTime
+    }
+
+    with(visitDetail.officialVisitors!!.single()) {
+      firstName isEqualTo CONTACT_MOORLAND_PRISONER.firstName
+      lastName isEqualTo CONTACT_MOORLAND_PRISONER.lastName
+      visitorEquipment!!.description isEqualTo "Laptop"
+      assistanceNotes isEqualTo "Wheelchair access needed"
+      phoneNumber isEqualTo CONTACT_MOORLAND_PRISONER.phoneNumber
+      emailAddress isEqualTo "contact@email.address"
+    }
+  }
+
+  @Test
+  fun `should error 404 when the visit prison is not in the users caseloads`() {
+    val response = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    stubUser(PENTONVILLE_PRISON_USER)
+
+    webTestClient.getOfficialVisitByIdNotInCaseload(response.officialVisitId)
+  }
+
+  @Test
+  fun `should error when the ID does not exist`() {
+    webTestClient.getOfficialVisitByInvalidId(999L)
+  }
 
   private fun WebTestClient.getOfficialVisitByPrisonAndId(prisonCode: String, officialVisitId: Long) = this
     .get()
@@ -124,4 +161,42 @@ class GetOfficialVisitByIdIntegrationTest : IntegrationTestBase() {
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody<OfficialVisitDetails>()
     .returnResult().responseBody!!
+
+  private fun WebTestClient.getOfficialVisitByInvalidPrisonAndId(prisonCode: String, officialVisitId: Long) = this
+    .get()
+    .uri("/official-visit/prison/$prisonCode/id/$officialVisitId")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN"))).exchange()
+    .expectStatus().is4xxClientError
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody().jsonPath("$.userMessage").isEqualTo("Official visit with id $officialVisitId and prison code $prisonCode not found")
+
+  private fun WebTestClient.getOfficialVisitById(officialVisitId: Long) = this
+    .get()
+    .uri("/official-visit/id/$officialVisitId")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS__R")))
+    .exchange()
+    .expectStatus().isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody<OfficialVisitDetails>()
+    .returnResult().responseBody!!
+
+  private fun WebTestClient.getOfficialVisitByInvalidId(officialVisitId: Long) = this
+    .get()
+    .uri("/official-visit/id/$officialVisitId")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN"))).exchange()
+    .expectStatus().is4xxClientError
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody().jsonPath("$.userMessage").isEqualTo("Official visit with id $officialVisitId was not found")
+
+  private fun WebTestClient.getOfficialVisitByIdNotInCaseload(officialVisitId: Long) = this
+    .get()
+    .uri("/official-visit/id/$officialVisitId")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = PENTONVILLE_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN"))).exchange()
+    .expectStatus().isNotFound
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody().jsonPath("$.userMessage").isEqualTo("The visit was not found or is restricted by caseload")
 }


### PR DESCRIPTION
This adds a new endpoint `GET /official-visit/id/{officialVisitId}`

If the calling client supplies a prison user and the official visit is found, it will check that the prison user has caseload access to that prison before returning the details. If not, it will return a 404 Not found.