### PR TITLE
OV-606 : get details of the notifications sent from a prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/NotificationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/NotificationEntity.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
 
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -25,5 +27,14 @@ class NotificationEntity(
 
   val govNotifyNotificationId: UUID,
 
+  @Enumerated(EnumType.STRING)
+  val emailStatus: NotificationEmailStatus = NotificationEmailStatus.PENDING,
+
   val createdTime: LocalDateTime = LocalDateTime.now(),
 )
+
+enum class NotificationEmailStatus {
+  PENDING,
+  SENT,
+  FAILED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/SentEmailRecordViewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/SentEmailRecordViewEntity.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.Immutable
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Entity
+@Immutable
+@Table(name = "v_sent_email_notifications")
+data class SentEmailRecordViewEntity(
+  @Id
+  val notificationId: Long,
+
+  val officialVisitId: Long,
+
+  val prisonCode: String,
+
+  val sentDateTime: LocalDateTime,
+
+  val visitDate: LocalDate,
+
+  val visitStartTime: LocalTime,
+
+  val visitEndTime: LocalTime,
+
+  val emailAddress: String,
+
+  @Enumerated(EnumType.STRING)
+  val emailStatus: NotificationEmailStatus,
+
+  val notificationType: String,
+
+  val prisonerNumber: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
@@ -2,18 +2,23 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications
 
 import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
+import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.Prisoner
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEmailStatus
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationRecipient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.LocationsService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.SentEmailsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.Email
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailService
@@ -27,6 +32,7 @@ class NotificationsFacade(
   private val prisonerSearchClient: PrisonerSearchClient,
   private val emailService: EmailService,
   private val notificationRepository: NotificationRepository,
+  private val sentEmailsService: SentEmailsService,
 ) {
   companion object {
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -52,6 +58,8 @@ class NotificationsFacade(
     NotificationResponse(officialVisitId, request.notificationType!!, recipients.toList())
   }
 
+  fun searchSentEmails(prisonCode: String, criteria: SentEmailSearchCriteria, page: Int, size: Int, user: User): PagedModel<SentEmailRecord> = sentEmailsService.searchSentEmails(prisonCode, criteria, page, size, user)
+
   /**
    * Will return the identifier of the notification created if successful, otherwise null.
    */
@@ -68,6 +76,7 @@ class NotificationsFacade(
             emailAddress = email.emailAddress,
             reason = email.type().name,
             govNotifyNotificationId = govNotifyNotificationId,
+            emailStatus = NotificationEmailStatus.PENDING,
             createdTime = LocalDateTime.now(),
           ),
         ).also { notificationId = it.notificationId }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/SentEmailSearchCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/SentEmailSearchCriteria.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+data class SentEmailSearchCriteria(
+
+  @Schema(description = "The start date filter (optional)", example = "2026-05-01")
+  val fromDate: LocalDate? = null,
+
+  @Schema(description = "The end date filter (optional)", example = "2026-05-31")
+  val toDate: LocalDate? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/SentEmailRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/SentEmailRecord.kt
@@ -39,21 +39,3 @@ data class SentEmailRecord(
   @Schema(description = "The description of the notification type", example = "Visit Created")
   val notificationTypeDescription: String,
 )
-
-data class SentEmailSearchResults(
-  @Schema(description = "The page content")
-  val content: List<SentEmailRecord>,
-  @Schema(description = "Paging metadata for the current response")
-  val page: SentEmailSearchPage,
-)
-
-data class SentEmailSearchPage(
-  @Schema(description = "The size of the current page", example = "20")
-  val size: Long,
-  @Schema(description = "The current page number (zero-based)", example = "0")
-  val number: Long,
-  @Schema(description = "The total number of elements", example = "150")
-  val totalElements: Long,
-  @Schema(description = "The total number of pages", example = "8")
-  val totalPages: Long,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/SentEmailSearchResults.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/SentEmailSearchResults.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class SentEmailRecord(
+  @Schema(description = "The official visit ID", example = "123")
+  val officialVisitId: Long,
+
+  @Schema(description = "The date the email was sent (YYYY-MM-DD format)", example = "2026-05-22")
+  val sentDate: String,
+
+  @Schema(description = "The full date and time the email was sent (ISO 8601 format)", example = "2026-05-22T10:30:00")
+  val sentDateTime: String,
+
+  @Schema(description = "The visit date (YYYY-MM-DD format)", example = "2026-06-01")
+  val visitDate: String,
+
+  @Schema(description = "The visit start time (HH:MM format)", example = "09:00")
+  val visitStartTime: String,
+
+  @Schema(description = "The visit end time (HH:MM format)", example = "10:00")
+  val visitEndTime: String,
+
+  @Schema(description = "The prisoner's full name", example = "John Smith")
+  val prisonerName: String,
+
+  @Schema(description = "The prisoner's number", example = "G1234AB")
+  val prisonerNumber: String,
+
+  @Schema(description = "The email address the notification was sent to", example = "user@example.com")
+  val emailAddress: String,
+
+  @Schema(description = "The status of the email delivery", example = "SENT")
+  val emailStatus: String,
+
+  @Schema(description = "The type of notification that was sent", example = "CREATE")
+  val notificationType: String,
+
+  @Schema(description = "The description of the notification type", example = "Visit Created")
+  val notificationTypeDescription: String,
+)
+
+data class SentEmailSearchResults(
+  @Schema(description = "The page content")
+  val content: List<SentEmailRecord>,
+  @Schema(description = "Paging metadata for the current response")
+  val page: SentEmailSearchPage,
+)
+
+data class SentEmailSearchPage(
+  @Schema(description = "The size of the current page", example = "20")
+  val size: Long,
+  @Schema(description = "The current page number (zero-based)", example = "0")
+  val number: Long,
+  @Schema(description = "The total number of elements", example = "150")
+  val totalElements: Long,
+  @Schema(description = "The total number of pages", example = "8")
+  val totalPages: Long,
+)
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/SentEmailSearchResults.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/SentEmailSearchResults.kt
@@ -57,4 +57,3 @@ data class SentEmailSearchPage(
   @Schema(description = "The total number of pages", example = "8")
   val totalPages: Long,
 )
-

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/SentEmailRecordViewRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/SentEmailRecordViewRepository.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.SentEmailRecordViewEntity
+import java.time.LocalDateTime
+
+@Repository
+interface SentEmailRecordViewRepository : ReadOnlyRepository<SentEmailRecordViewEntity, Long> {
+
+  fun findByPrisonCodeOrderBySentDateTimeDesc(
+    prisonCode: String,
+    pageable: Pageable,
+  ): Page<SentEmailRecordViewEntity>
+
+  fun findByPrisonCodeAndSentDateTimeGreaterThanEqualOrderBySentDateTimeDesc(
+    prisonCode: String,
+    fromDateTime: LocalDateTime,
+    pageable: Pageable,
+  ): Page<SentEmailRecordViewEntity>
+
+  fun findByPrisonCodeAndSentDateTimeLessThanOrderBySentDateTimeDesc(
+    prisonCode: String,
+    toDateTimeExclusive: LocalDateTime,
+    pageable: Pageable,
+  ): Page<SentEmailRecordViewEntity>
+
+  fun findByPrisonCodeAndSentDateTimeGreaterThanEqualAndSentDateTimeLessThanOrderBySentDateTimeDesc(
+    prisonCode: String,
+    fromDateTime: LocalDateTime,
+    toDateTimeExclusive: LocalDateTime,
+    pageable: Pageable,
+  ): Page<SentEmailRecordViewEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/NotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/NotificationsController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.Valid
+import org.springframework.data.web.PagedModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -22,7 +23,10 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.client.manageusers.model.E
 import uk.gov.justice.digital.hmpps.officialvisitsapi.config.getLocalRequestContext
 import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationsFacade
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailSearchResults
 
 @Tag(name = "Notifications")
 @RestController
@@ -66,4 +70,48 @@ class NotificationsController(private val notificationFacade: NotificationsFacad
     request: NotificationRequest,
     httpRequest: HttpServletRequest,
   ) = notificationFacade.sendNotification(officialVisitId, request, httpRequest.getLocalRequestContext().user)
+
+  @Operation(summary = "Endpoint to retrieve a list of sent email notifications with search and pagination support.")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The paginated response containing the list of sent email notifications",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = SentEmailSearchResults::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @PostMapping(path = ["/prison/{prisonCode}/sent-emails"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__R', 'ROLE_OFFICIAL_VISITS_RW')")
+  fun searchSentEmails(
+    @PathVariable @Parameter(
+      name = "prisonCode",
+      description = "The prison code",
+      example = "MDI",
+      required = true,
+    ) prisonCode: String,
+    @Valid
+    @RequestBody
+    @Parameter(description = "The request containing sent-email search criteria", required = true)
+    request: SentEmailSearchCriteria,
+    @Parameter(
+      description = "Zero-based page index (0..N)",
+      name = "page",
+      schema = Schema(type = "integer", defaultValue = "0"),
+    )
+    page: Int = 0,
+    @Parameter(
+      description = "The size of the page to be returned",
+      name = "size",
+      schema = Schema(type = "integer", defaultValue = "10"),
+    )
+    size: Int = 20,
+    httpRequest: HttpServletRequest,
+  ): PagedModel<SentEmailRecord> = notificationFacade.searchSentEmails(prisonCode, request, page, size, httpRequest.getLocalRequestContext().user)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/NotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/NotificationsController.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.Notification
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailSearchResults
 
 @Tag(name = "Notifications")
 @RestController
@@ -72,20 +71,6 @@ class NotificationsController(private val notificationFacade: NotificationsFacad
   ) = notificationFacade.sendNotification(officialVisitId, request, httpRequest.getLocalRequestContext().user)
 
   @Operation(summary = "Endpoint to retrieve a list of sent email notifications with search and pagination support.")
-  @ApiResponses(
-    value = [
-      ApiResponse(
-        responseCode = "200",
-        description = "The paginated response containing the list of sent email notifications",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = SentEmailSearchResults::class),
-          ),
-        ],
-      ),
-    ],
-  )
   @PostMapping(path = ["/prison/{prisonCode}/sent-emails"], consumes = [MediaType.APPLICATION_JSON_VALUE])
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__R', 'ROLE_OFFICIAL_VISITS_RW')")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/SentEmailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/SentEmailsService.kt
@@ -1,0 +1,131 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.web.PagedModel
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.SentEmailRecordViewEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.SentEmailRecordViewRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.SentEmailSearchInfo
+import java.time.format.DateTimeFormatter
+
+@Service
+@Transactional(readOnly = true)
+class SentEmailsService(
+  private val sentEmailRecordViewRepository: SentEmailRecordViewRepository,
+  private val prisonerSearchClient: PrisonerSearchClient,
+  private val metricsService: MetricsService,
+) {
+
+  fun searchSentEmails(prisonCode: String, criteria: SentEmailSearchCriteria, page: Int, size: Int, user: User): PagedModel<SentEmailRecord> {
+    require(page >= 0) { "Page number must be greater than or equal to zero" }
+    require(size > 0) { "Page size must be greater than zero" }
+    val normalizedPrisonCode = prisonCode.trim()
+    require(normalizedPrisonCode.isNotEmpty()) { "Prison code must be provided" }
+    require(criteria.fromDate == null || criteria.toDate == null || !criteria.fromDate.isAfter(criteria.toDate)) {
+      "From date must be on or before to date"
+    }
+
+    val fromDateTime = criteria.fromDate?.atStartOfDay()
+    val toDateTimeExclusive = criteria.toDate?.plusDays(1)?.atStartOfDay()
+
+    val pageable = PageRequest.of(page, size)
+    val pageResult = when {
+      fromDateTime != null && toDateTimeExclusive != null ->
+        sentEmailRecordViewRepository.findByPrisonCodeAndSentDateTimeGreaterThanEqualAndSentDateTimeLessThanOrderBySentDateTimeDesc(
+          normalizedPrisonCode,
+          fromDateTime,
+          toDateTimeExclusive,
+          pageable,
+        )
+
+      fromDateTime != null ->
+        sentEmailRecordViewRepository.findByPrisonCodeAndSentDateTimeGreaterThanEqualOrderBySentDateTimeDesc(
+          normalizedPrisonCode,
+          fromDateTime,
+          pageable,
+        )
+
+      toDateTimeExclusive != null ->
+        sentEmailRecordViewRepository.findByPrisonCodeAndSentDateTimeLessThanOrderBySentDateTimeDesc(
+          normalizedPrisonCode,
+          toDateTimeExclusive,
+          pageable,
+        )
+
+      else -> sentEmailRecordViewRepository.findByPrisonCodeOrderBySentDateTimeDesc(normalizedPrisonCode, pageable)
+    }
+
+    metricsService.send(
+      eventType = MetricsEvents.SENT_EMAIL_SEARCH,
+      info = SentEmailSearchInfo(
+        prisonCode = normalizedPrisonCode,
+        username = user.username,
+        fromDate = criteria.fromDate,
+        toDate = criteria.toDate,
+        numberOfResults = pageResult.numberOfElements,
+      ),
+    )
+
+    val prisonerNumbers = pageResult.content.map { it.prisonerNumber }.distinct()
+
+    val prisonerMap = if (prisonerNumbers.isEmpty()) {
+      emptyMap()
+    } else {
+      prisonerSearchClient.findByPrisonerNumbers(
+        prisonerNumbers,
+        prisonerNumbers.size,
+      ).associateBy { it.prisonerNumber }
+    }
+
+    return PagedModel(
+      pageResult.map { viewEntity ->
+        val prisoner = prisonerMap[viewEntity.prisonerNumber]
+        val prisonerName = prisoner?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown"
+
+        viewEntity.toSentEmailRecord(prisonerName = prisonerName)
+      },
+    )
+  }
+
+  private fun SentEmailRecordViewEntity.toSentEmailRecord(prisonerName: String): SentEmailRecord {
+    val emailType = notificationType.toEmailTypeOrNull()
+    val normalizedNotificationType = emailType?.toApiNotificationType() ?: notificationType
+
+    return SentEmailRecord(
+      officialVisitId = officialVisitId,
+      sentDate = sentDateTime.toLocalDate().format(dateFormatter),
+      sentDateTime = sentDateTime.format(dateTimeFormatter),
+      visitDate = visitDate.format(dateFormatter),
+      visitStartTime = visitStartTime.format(timeFormatter),
+      visitEndTime = visitEndTime.format(timeFormatter),
+      prisonerName = prisonerName,
+      prisonerNumber = prisonerNumber,
+      emailAddress = emailAddress,
+      emailStatus = emailStatus.name,
+      notificationType = normalizedNotificationType,
+      notificationTypeDescription = when (emailType) {
+        EmailType.OFFICIAL_VISIT_CREATED -> "Visit Created"
+        else -> "Unknown"
+      },
+    )
+  }
+
+  private fun String.toEmailTypeOrNull(): EmailType? = runCatching { EmailType.valueOf(this) }.getOrNull()
+
+  private fun EmailType.toApiNotificationType(): String = when (this) {
+    EmailType.OFFICIAL_VISIT_CREATED -> "CREATE"
+  }
+
+  private companion object {
+    val dateFormatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+    val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+    val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/metrics/MetricsEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/metrics/MetricsEvents.kt
@@ -59,6 +59,12 @@ enum class MetricsEvents(val eventType: String) {
       additionalInformation = additionalInformation,
     )
   },
+  SENT_EMAIL_SEARCH("SentEmailSearch") {
+    override fun event(additionalInformation: MetricInfo) = OfficialVisitMetricTelemetry(
+      eventType = eventType,
+      additionalInformation = additionalInformation,
+    )
+  },
   ;
 
   abstract fun event(
@@ -92,6 +98,10 @@ data class OfficialVisitMetricTelemetry(
       is TimeSlotInfo -> {
         baseMap + additionalInformation.timeSLotInfo()
       }
+
+      is SentEmailSearchInfo -> {
+        baseMap + additionalInformation.sentEmailSearchAdditionalInfo()
+      }
     }
   }
 
@@ -100,6 +110,11 @@ data class OfficialVisitMetricTelemetry(
       visitMetrics(additionalInformation)
     }
     is SearchInfo -> {
+      mapOf(
+        "number_of_results" to additionalInformation.numberOfResults.toDouble(),
+      )
+    }
+    is SentEmailSearchInfo -> {
       mapOf(
         "number_of_results" to additionalInformation.numberOfResults.toDouble(),
       )
@@ -153,6 +168,11 @@ private fun SearchInfo.searchAdditionalInfo(): Map<String, String> = mapOf(
   "location_Ids" to "$locationIds",
 )
 
+private fun SentEmailSearchInfo.sentEmailSearchAdditionalInfo(): Map<String, String> = mapOf(
+  "from_date" to "${fromDate ?: ""}",
+  "to_date" to "${toDate ?: ""}",
+)
+
 sealed class MetricInfo(
   open val source: Source = Source.DPS,
   open val username: String,
@@ -196,4 +216,13 @@ data class TimeSlotInfo(
   override val username: String,
   override val prisonCode: String,
   val dayCode: String,
+) : MetricInfo(source = source, username = username, prisonCode = prisonCode)
+
+data class SentEmailSearchInfo(
+  override val source: Source = Source.DPS,
+  override val username: String,
+  override val prisonCode: String,
+  val fromDate: LocalDate? = null,
+  val toDate: LocalDate? = null,
+  val numberOfResults: Int = 0,
 ) : MetricInfo(source = source, username = username, prisonCode = prisonCode)

--- a/src/main/resources/migrations/common/R__v_sent_email_notifications.sql
+++ b/src/main/resources/migrations/common/R__v_sent_email_notifications.sql
@@ -1,0 +1,19 @@
+--
+-- View to provide sent email notification data for reporting and search
+--
+DROP VIEW IF EXISTS v_sent_email_notifications;
+
+CREATE VIEW v_sent_email_notifications AS
+SELECT n.notification_id,
+       n.official_visit_id,
+       ov.prison_code,
+       n.created_time AS sent_date_time,
+       ov.visit_date,
+       ov.start_time AS visit_start_time,
+       ov.end_time AS visit_end_time,
+       n.email_address,
+       n.email_status,
+       n.reason AS notification_type,
+       ov.prisoner_number
+  FROM notification n
+  JOIN official_visit ov ON ov.official_visit_id = n.official_visit_id

--- a/src/main/resources/migrations/common/V2026.05.22__add_notification_status_column.sql
+++ b/src/main/resources/migrations/common/V2026.05.22__add_notification_status_column.sql
@@ -1,0 +1,17 @@
+-- Add status column to notification table to track email delivery status
+ALTER TABLE notification
+ADD COLUMN email_status varchar(20) DEFAULT 'PENDING' NOT NULL;
+
+-- Indexes to support email search by status
+CREATE INDEX IF NOT EXISTS idx_notification_email_status ON notification(email_status);
+
+-- Indexes to support email search by visit id and created date-time
+CREATE INDEX IF NOT EXISTS idx_notification_visit_id_created_time
+    ON notification (official_visit_id, created_time DESC);
+
+-- Indexes to support sent email search by prison and sent date-time
+CREATE INDEX IF NOT EXISTS idx_official_visit_prison_code_visit_id
+    ON official_visit (prison_code, official_visit_id);
+
+
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacadeTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.Notification
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.LocationsService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.SentEmailsService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.Email
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailType
@@ -40,8 +41,9 @@ class NotificationsFacadeTest {
   private val emailService: EmailService = mock()
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val notificationRepository: NotificationRepository = mock()
+  private val sentEmailsService: SentEmailsService = mock()
   private val notification: NotificationEntity = mock()
-  private val facade = NotificationsFacade(officialVisitRepository, locationsService, prisonerSearchClient, emailService, notificationRepository)
+  private val facade = NotificationsFacade(officialVisitRepository, locationsService, prisonerSearchClient, emailService, notificationRepository, sentEmailsService)
 
   @BeforeEach
   fun beforeEach() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
@@ -2,7 +2,11 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.integration.resource
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.transaction.annotation.Transactional
@@ -11,6 +15,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactly
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createOfficialVisitRequest
@@ -19,17 +24,27 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.now
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationRecipient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.SentEmailSearchInfo
+import java.time.LocalDate
 import java.util.UUID
 
 class NotificationsIntegrationTest : IntegrationTestBase() {
+
+  @MockitoBean
+  private lateinit var metricsService: MetricsService
 
   private val location = moorlandLocation.copy(id = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"))
 
@@ -63,6 +78,19 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
           type = "O",
           contactId = officialVisitor.contactId!!,
           prisonerContactId = officialVisitor.prisonerContactId!!,
+        ),
+      ),
+    )
+
+    prisonerSearchApi().stubSearchPrisonersByPrisonerNumbers(
+      idsBeingSearchFor = listOf(MOORLAND_PRISONER.number),
+      prisonersToReturn = listOf(
+        prisonerSearchPrisoner(
+          prisonerNumber = MOORLAND_PRISONER.number,
+          prisonCode = MOORLAND,
+          firstName = MOORLAND_PRISONER.firstName,
+          lastName = MOORLAND_PRISONER.lastName,
+          bookingId = MOORLAND_PRISONER.bookingId,
         ),
       ),
     )
@@ -117,6 +145,138 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
     }
   }
 
+  @Test
+  fun `should search sent emails with pagination`() {
+    // Create a visit and send a notification
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    webTestClient.send(
+      officialVisitId = scheduledVisit.officialVisitId,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email@address.com"),
+      ),
+    )
+
+    // Search for sent emails
+    val result = webTestClient.searchSentEmails(
+      prisonCode = MOORLAND,
+      request = SentEmailSearchCriteria(fromDate = null, toDate = null),
+      page = 0,
+      size = 10,
+    )
+
+    result.page.totalElements isEqualTo 1L
+    result.content.size isEqualTo 1
+    result.page.totalPages isEqualTo 1L
+    result.page.number isEqualTo 0L
+    result.page.size isEqualTo 10L
+
+    with(result.content[0]) {
+      officialVisitId isEqualTo scheduledVisit.officialVisitId
+      emailAddress isEqualTo "email@address.com"
+      emailStatus isEqualTo "SENT"
+      notificationType isEqualTo "CREATE"
+      notificationTypeDescription isEqualTo "Visit Created"
+      prisonerNumber isEqualTo MOORLAND_PRISONER.number
+      prisonerName isEqualTo "${MOORLAND_PRISONER.firstName} ${MOORLAND_PRISONER.lastName}"
+    }
+
+    verify(metricsService).send(
+      eventType = eq(MetricsEvents.SENT_EMAIL_SEARCH),
+      info = any<SentEmailSearchInfo>(),
+    )
+  }
+
+  @Test
+  fun `should search sent emails with date filter`() {
+    // Create a visit and send a notification
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    webTestClient.send(
+      officialVisitId = scheduledVisit.officialVisitId,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email@address.com"),
+      ),
+    )
+
+    // Search with matching date range
+    val resultWithMatch = webTestClient.searchSentEmails(
+      prisonCode = MOORLAND,
+      request = SentEmailSearchCriteria(
+        fromDate = LocalDate.now().minusDays(1),
+        toDate = LocalDate.now().plusDays(1),
+      ),
+      page = 0,
+      size = 10,
+    )
+
+    resultWithMatch.page.totalElements isEqualTo 1L
+    resultWithMatch.content.size isEqualTo 1
+
+    // Search with non-matching date range
+    val resultWithoutMatch = webTestClient.searchSentEmails(
+      prisonCode = MOORLAND,
+      request = SentEmailSearchCriteria(
+        fromDate = LocalDate.now().plusDays(30),
+        toDate = LocalDate.now().plusDays(60),
+      ),
+      page = 0,
+      size = 10,
+    )
+
+    resultWithoutMatch.page.totalElements isEqualTo 0L
+    resultWithoutMatch.content.isEmpty()
+  }
+
+  @Test
+  fun `should include records when from and to dates are the same day`() {
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    webTestClient.send(
+      officialVisitId = scheduledVisit.officialVisitId,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email@address.com"),
+      ),
+    )
+
+    val today = LocalDate.now()
+    val result = webTestClient.searchSentEmails(
+      prisonCode = MOORLAND,
+      request = SentEmailSearchCriteria(fromDate = today, toDate = today),
+      page = 0,
+      size = 10,
+    )
+
+    result.page.totalElements isEqualTo 1L
+    result.content.size isEqualTo 1
+  }
+
+  @Test
+  fun `should return no sent emails for a different prison code`() {
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    webTestClient.send(
+      officialVisitId = scheduledVisit.officialVisitId,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email@address.com"),
+      ),
+    )
+
+    val result = webTestClient.searchSentEmails(
+      prisonCode = PENTONVILLE,
+      request = SentEmailSearchCriteria(fromDate = null, toDate = null),
+      page = 0,
+      size = 10,
+    )
+
+    result.page.totalElements isEqualTo 0L
+    result.content.isEmpty()
+  }
+
   private fun WebTestClient.send(officialVisitId: Long, request: NotificationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
     .post()
     .uri("/notification/$officialVisitId")
@@ -128,4 +288,34 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody<NotificationResponse>()
     .returnResult().responseBody!!
+
+  private fun WebTestClient.searchSentEmails(
+    prisonCode: String,
+    request: SentEmailSearchCriteria,
+    page: Int = 0,
+    size: Int = 10,
+    prisonUser: PrisonUser = MOORLAND_PRISON_USER,
+  ) = this
+    .post()
+    .uri("/notification/prison/$prisonCode/sent-emails?page=$page&size=$size")
+    .bodyValue(request)
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
+    .exchange()
+    .expectStatus().isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody<SentEmailSearchResponse>()
+    .returnResult().responseBody!!
 }
+
+private data class SentEmailSearchResponse(
+  val content: List<SentEmailRecord>,
+  val page: PageMetadata,
+)
+
+private data class PageMetadata(
+  val size: Long,
+  val number: Long,
+  val totalElements: Long,
+  val totalPages: Long,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
@@ -175,7 +175,7 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
     with(result.content[0]) {
       officialVisitId isEqualTo scheduledVisit.officialVisitId
       emailAddress isEqualTo "email@address.com"
-      emailStatus isEqualTo "SENT"
+      emailStatus isEqualTo "PENDING"
       notificationType isEqualTo "CREATE"
       notificationTypeDescription isEqualTo "Visit Created"
       prisonerNumber isEqualTo MOORLAND_PRISONER.number

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/SentEmailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/SentEmailsServiceTest.kt
@@ -88,7 +88,7 @@ class SentEmailsServiceTest {
     result.content.size isEqualTo 1
     result.content[0].prisonerName isEqualTo "John Smith"
     result.content[0].prisonerNumber isEqualTo "G1234AB"
-    result.content[0].emailStatus isEqualTo "SENT"
+    result.content[0].emailStatus isEqualTo "PENDING"
     result.content[0].notificationType isEqualTo "CREATE"
     result.content[0].notificationTypeDescription isEqualTo "Visit Created"
     val fromDateTimeCaptor = argumentCaptor<LocalDateTime>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/SentEmailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/SentEmailsServiceTest.kt
@@ -1,0 +1,188 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.Prisoner
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEmailStatus
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.SentEmailRecordViewEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.contains
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.SentEmailRecordViewRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.SentEmailSearchInfo
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class SentEmailsServiceTest {
+  private val sentEmailRecordViewRepository: SentEmailRecordViewRepository = mock()
+  private val prisonerSearchClient: PrisonerSearchClient = mock()
+  private val metricsService: MetricsService = mock()
+
+  private val service = SentEmailsService(sentEmailRecordViewRepository, prisonerSearchClient, metricsService)
+
+  @Test
+  fun `should search sent emails with pagination`() {
+    // Given
+    val criteria = SentEmailSearchCriteria(
+      fromDate = LocalDate.of(2026, 5, 1),
+      toDate = LocalDate.of(2026, 5, 31),
+    )
+
+    val viewEntity = SentEmailRecordViewEntity(
+      notificationId = 100L,
+      officialVisitId = 1L,
+      prisonCode = "MDI",
+      sentDateTime = LocalDateTime.of(2026, 5, 22, 10, 30),
+      visitDate = LocalDate.of(2026, 6, 1),
+      visitStartTime = LocalTime.of(9, 0),
+      visitEndTime = LocalTime.of(10, 0),
+      emailAddress = "user@example.com",
+      emailStatus = NotificationEmailStatus.PENDING,
+      notificationType = EmailType.OFFICIAL_VISIT_CREATED.name,
+      prisonerNumber = "G1234AB",
+    )
+
+    val prisoner = Prisoner(
+      prisonerNumber = "G1234AB",
+      firstName = "John",
+      lastName = "Smith",
+      dateOfBirth = LocalDate.of(1990, 1, 1),
+    )
+
+    val pageResult: Page<SentEmailRecordViewEntity> = PageImpl(
+      listOf(viewEntity),
+      PageRequest.of(0, 10),
+      1,
+    )
+
+    whenever(
+      sentEmailRecordViewRepository.findByPrisonCodeAndSentDateTimeGreaterThanEqualAndSentDateTimeLessThanOrderBySentDateTimeDesc(
+        any(),
+        any(),
+        any(),
+        any(),
+      ),
+    ).thenReturn(pageResult)
+    whenever(prisonerSearchClient.findByPrisonerNumbers(any(), any())).thenReturn(listOf(prisoner))
+
+    // When
+    val result = service.searchSentEmails(prisonCode = "MDI", criteria = criteria, page = 0, size = 10, user = MOORLAND_PRISON_USER)
+
+    // Then
+    result.metadata.totalElements isEqualTo 1L
+    result.content.size isEqualTo 1
+    result.content[0].prisonerName isEqualTo "John Smith"
+    result.content[0].prisonerNumber isEqualTo "G1234AB"
+    result.content[0].emailStatus isEqualTo "SENT"
+    result.content[0].notificationType isEqualTo "CREATE"
+    result.content[0].notificationTypeDescription isEqualTo "Visit Created"
+    val fromDateTimeCaptor = argumentCaptor<LocalDateTime>()
+    val toDateTimeCaptor = argumentCaptor<LocalDateTime>()
+    verify(sentEmailRecordViewRepository).findByPrisonCodeAndSentDateTimeGreaterThanEqualAndSentDateTimeLessThanOrderBySentDateTimeDesc(
+      eq("MDI"),
+      fromDateTimeCaptor.capture(),
+      toDateTimeCaptor.capture(),
+      any(),
+    )
+    fromDateTimeCaptor.firstValue isEqualTo LocalDateTime.of(2026, 5, 1, 0, 0)
+    toDateTimeCaptor.firstValue isEqualTo LocalDateTime.of(2026, 6, 1, 0, 0)
+    verify(metricsService).send(
+      eventType = eq(MetricsEvents.SENT_EMAIL_SEARCH),
+      info = eq(
+        SentEmailSearchInfo(
+          prisonCode = "MDI",
+          username = MOORLAND_PRISON_USER.username,
+          fromDate = LocalDate.of(2026, 5, 1),
+          toDate = LocalDate.of(2026, 5, 31),
+          numberOfResults = 1,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun `should throw exception when page number is negative`() {
+    // Given
+    val criteria = SentEmailSearchCriteria(
+      fromDate = null,
+      toDate = null,
+    )
+
+    // Then
+    assertThrows<IllegalArgumentException> {
+      service.searchSentEmails(prisonCode = "MDI", criteria = criteria, page = -1, size = 10, user = MOORLAND_PRISON_USER)
+    }.message?.contains("Page number must be greater than or equal to zero")
+  }
+
+  @Test
+  fun `should throw exception when page size is zero`() {
+    // Given
+    val criteria = SentEmailSearchCriteria(
+      fromDate = null,
+      toDate = null,
+    )
+
+    // Then
+    assertThrows<IllegalArgumentException> {
+      service.searchSentEmails(prisonCode = "MDI", criteria = criteria, page = 0, size = 0, user = MOORLAND_PRISON_USER)
+    }.message?.contains("Page size must be greater than zero")
+  }
+
+  @Test
+  fun `should throw exception when prison code is blank`() {
+    // Given
+    val criteria = SentEmailSearchCriteria(
+      fromDate = null,
+      toDate = null,
+    )
+
+    // Then
+    assertThrows<IllegalArgumentException> {
+      service.searchSentEmails(prisonCode = " ", criteria = criteria, page = 0, size = 10, user = MOORLAND_PRISON_USER)
+    }.message?.contains("Prison code must be provided")
+  }
+
+  @Test
+  fun `should search without date filters`() {
+    val criteria = SentEmailSearchCriteria(
+      fromDate = null,
+      toDate = null,
+    )
+
+    whenever(sentEmailRecordViewRepository.findByPrisonCodeOrderBySentDateTimeDesc(any(), any()))
+      .thenReturn(PageImpl(emptyList(), PageRequest.of(0, 10), 0))
+
+    val result = service.searchSentEmails(prisonCode = "MDI", criteria = criteria, page = 0, size = 10, user = MOORLAND_PRISON_USER)
+
+    result.content.size isEqualTo 0
+    result.metadata.totalElements isEqualTo 0L
+    verify(sentEmailRecordViewRepository).findByPrisonCodeOrderBySentDateTimeDesc(eq("MDI"), any())
+  }
+
+  @Test
+  fun `should throw exception when from date is after to date`() {
+    val criteria = SentEmailSearchCriteria(
+      fromDate = LocalDate.of(2026, 5, 31),
+      toDate = LocalDate.of(2026, 5, 1),
+    )
+
+    assertThrows<IllegalArgumentException> {
+      service.searchSentEmails(prisonCode = "MDI", criteria = criteria, page = 0, size = 10, user = MOORLAND_PRISON_USER)
+    }.message?.contains("From date must be on or before to date")
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature for searching and retrieving sent email notifications with filtering and pagination, along with supporting changes to the data model, API, and metrics. 


Test evidence:
<img width="802" height="905" alt="image" src="https://github.com/user-attachments/assets/0db7dc4f-8fbf-4464-9491-00c674a64789" />
<img width="814" height="307" alt="image" src="https://github.com/user-attachments/assets/177a90f0-d2f2-4dfd-a323-429dd3890560" />


Integrate tests with UI:
<img width="597" height="493" alt="image" src="https://github.com/user-attachments/assets/8308ac16-e592-4a56-b50e-296407281c69" />

