### PR TITLE
OV-726 remove nullability from non-nullable request objects fields due to open API changes using the type and not the annotations.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationsFacade.kt
@@ -50,12 +50,12 @@ class NotificationsFacade(
       request.emailAddresses.distinct().forEach { emailAddress ->
         sendOfficialVisitEmail(
           officialVisit.officialVisitId,
-          getEmail(request.notificationType!!, officialVisit, emailAddress, prisoner, location, user),
+          getEmail(request.notificationType, officialVisit, emailAddress, prisoner, location, user),
         )?.let { notificationId -> add(NotificationRecipient(emailAddress, notificationId)) }
       }
     }
 
-    NotificationResponse(officialVisitId, request.notificationType!!, recipients.toList())
+    NotificationResponse(officialVisitId, request.notificationType, recipients.toList())
   }
 
   fun searchSentEmails(prisonCode: String, criteria: SentEmailSearchCriteria, page: Int, size: Int, user: User): PagedModel<SentEmailRecord> = sentEmailsService.searchSentEmails(prisonCode, criteria, page, size, user)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/CreateOfficialVisitRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/CreateOfficialVisitRequest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.SearchLevelType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitType
@@ -12,36 +11,30 @@ import java.time.LocalTime
 import java.util.UUID
 
 data class CreateOfficialVisitRequest(
-  @field:NotNull(message = "The prison visit slot identifier for the official visit is mandatory")
   val prisonVisitSlotId: Long,
 
   @field:NotBlank(message = "The prisoner number for the official visit is mandatory")
   @field:Size(max = 7, message = "Prisoner number must not exceed {max} characters")
   @Schema(description = "The prisoner number (NOMIS ID)", example = "A1234AA")
-  val prisonerNumber: String?,
+  val prisonerNumber: String,
 
-  @field:NotNull(message = "The date for the official visit is mandatory")
   @Schema(description = "The date the official visit will take place", example = "2022-12-23")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd")
-  val visitDate: LocalDate?,
+  val visitDate: LocalDate,
 
-  @field:NotNull(message = "The start time of the official visit is mandatory")
   @Schema(description = "The start time of the official visit", example = "10:00")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-  val startTime: LocalTime?,
+  val startTime: LocalTime,
 
-  @field:NotNull(message = "The end time of the official visit is mandatory")
   @Schema(description = "The end time of the official visit", example = "11:00")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-  val endTime: LocalTime?,
+  val endTime: LocalTime,
 
-  @field:NotNull(message = "The DPS location ID is mandatory")
   @Schema(description = "The DPS location ID where the official visit is to take place", example = "aaaa-bbbb-9f9f9f9f-9f9f9f9f")
-  val dpsLocationId: UUID?,
+  val dpsLocationId: UUID,
 
-  @field:NotNull(message = "Visit type code is mandatory")
   @Schema(description = "The visit type code", example = "IN_PERSON", required = true, allowableValues = ["IN_PERSON", "TELEPHONE", "VIDEO"])
-  val visitTypeCode: VisitType?,
+  val visitTypeCode: VisitType,
 
   @field:Size(max = 240, message = "The staff notes should not exceed {max} characters")
   @Schema(description = "Notes for staff that will not be shared on movement slips", example = "Staff notes")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/NotificationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/NotificationRequest.kt
@@ -4,14 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationType
 
 data class NotificationRequest(
-  @Schema(description = "The type of notification to send", example = "CREATE")
-  @field:NotNull(message = "The email type is mandatory")
-  val notificationType: NotificationType?,
+  @Schema(name = "Notification Type", description = "The type of notification to send", example = "CREATE")
+  val notificationType: NotificationType,
 
   @Schema(description = "The recipient email address to send the notification to")
   @field:NotEmpty(message = "The email address is mandatory")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCancellationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCancellationRequest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.AssertTrue
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitCompletionType
 
@@ -13,8 +12,7 @@ data class OfficialVisitCancellationRequest(
     example = "PRISONER_CANCELLED",
     allowableValues = ["PRISONER_CANCELLED", "STAFF_CANCELLED", "VISITOR_CANCELLED"],
   )
-  @field:NotNull(message = "The cancellation reason is mandatory")
-  val cancellationReason: VisitCompletionType?,
+  val cancellationReason: VisitCompletionType,
 
   @field:Size(max = 240, message = "The cancellation notes should not exceed {max} characters")
   @Schema(description = "Optional notes containing details of the reason for cancellation", example = "Prisoner in hospital")
@@ -22,5 +20,5 @@ data class OfficialVisitCancellationRequest(
 ) {
   @JsonIgnore
   @AssertTrue(message = "The cancellation reason is not valid or allowed")
-  private fun isInvalidCancellationReason() = cancellationReason == null || cancellationReason.isCancellation
+  private fun isInvalidCancellationReason() = cancellationReason.isCancellation
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCompletionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCompletionRequest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.SearchLevelType
@@ -16,29 +15,26 @@ data class OfficialVisitCompletionRequest(
     example = "NORMAL",
     allowableValues = ["NORMAL", "PRISONER_EARLY", "PRISONER_REFUSED", "STAFF_EARLY", "VISITOR_DENIED", "VISITOR_EARLY", "VISITOR_NO_SHOW"],
   )
-  @field:NotNull(message = "The completion reason is mandatory")
-  val completionReason: VisitCompletionType?,
+  val completionReason: VisitCompletionType,
 
   @field:Size(max = 240, message = "The completion notes should not exceed {max} characters")
   @Schema(description = "Optional notes containing details of the completion", example = "The visitor was late arriving so the the prisoner may need another visit to be arranged.")
   val completionNotes: String? = null,
 
-  @field:NotNull(message = "The prisoner attendance is mandatory")
-  val prisonerAttendance: AttendanceType?,
+  val prisonerAttendance: AttendanceType,
 
-  @field:NotNull(message = "The prisoner search type is mandatory")
-  val prisonerSearchType: SearchLevelType?,
+  val prisonerSearchType: SearchLevelType,
 
   @field:NotEmpty(message = "The visitors attendance is mandatory")
   val visitorAttendance: List<OfficialVisitorAttendance>,
 ) {
   @JsonIgnore
   @AssertTrue(message = "The completion reason is not valid or allowed")
-  private fun isInvalidCompletionReason() = completionReason == null || !completionReason.isCancellation
+  private fun isInvalidCompletionReason() = !completionReason.isCancellation
 }
 
 data class OfficialVisitorAttendance(
   val officialVisitorId: Long,
 
-  val visitorAttendance: AttendanceType?,
+  val visitorAttendance: AttendanceType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitSummarySearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitSummarySearchRequest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitStatusType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitType
 import java.time.LocalDate
@@ -11,13 +10,11 @@ data class OfficialVisitSummarySearchRequest(
   @Schema(description = "The search term can be a prisoner number, name or partial name.  Must be a minimum of 2 characters or not provided.", example = "Smith")
   val searchTerm: String? = null,
 
-  @field:NotNull(message = "The start date for search mandatory")
   @Schema(description = "The earliest date the official visits will start", example = "2022-12-23")
-  val startDate: LocalDate?,
+  val startDate: LocalDate,
 
-  @field:NotNull(message = "The end date for search mandatory")
   @Schema(description = "The latest date the official visits will end", example = "2022-12-23")
-  val endDate: LocalDate?,
+  val endDate: LocalDate,
 
   @Schema(description = "The visit types to search for", examples = ["IN_PERSON", "VIDEO", "TELEPHONE", "UNKNOWN"])
   val visitTypes: List<VisitType>?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitUpdateSlotRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitUpdateSlotRequest.kt
@@ -2,36 +2,29 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitType
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
 data class OfficialVisitUpdateSlotRequest(
-  @field:NotNull(message = "The prison visit slot identifier for the official visit is mandatory")
-  val prisonVisitSlotId: Long?,
+  val prisonVisitSlotId: Long,
 
-  @field:NotNull(message = "The date for the official visit is mandatory")
   @Schema(description = "The date the official visit will take place", example = "2022-12-23")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd")
-  val visitDate: LocalDate?,
+  val visitDate: LocalDate,
 
-  @field:NotNull(message = "The start time of the official visit is mandatory")
   @Schema(description = "The start time of the official visit", example = "10:00")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-  val startTime: LocalTime?,
+  val startTime: LocalTime,
 
-  @field:NotNull(message = "The end time of the official visit is mandatory")
   @Schema(description = "The end time of the official visit", example = "11:00")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-  val endTime: LocalTime?,
+  val endTime: LocalTime,
 
-  @field:NotNull(message = "The DPS location ID is mandatory")
   @Schema(description = "The DPS location ID where the official visit is to take place", example = "aaaa-bbbb-9f9f9f9f-9f9f9f9f")
-  val dpsLocationId: UUID?,
+  val dpsLocationId: UUID,
 
-  @field:NotNull(message = "Visit type code is mandatory")
   @Schema(description = "The visit type code", example = "IN_PERSON", required = true)
-  val visitTypeCode: VisitType?,
+  val visitTypeCode: VisitType,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OverlappingVisitsCriteriaRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OverlappingVisitsCriteriaRequest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import java.time.LocalTime
@@ -12,22 +11,19 @@ data class OverlappingVisitsCriteriaRequest(
   @field:NotBlank(message = "The prisoner number is mandatory")
   @field:Size(max = 7, message = "Prisoner number must not exceed {max} characters")
   @Schema(description = "The prisoner number (NOMIS ID) to check for overlapping", example = "A1234AA")
-  val prisonerNumber: String?,
+  val prisonerNumber: String,
 
-  @field:NotNull(message = "The date is mandatory")
   @Schema(description = "The date on which to check for overlapping", example = "2022-12-23")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd")
-  val visitDate: LocalDate?,
+  val visitDate: LocalDate,
 
-  @field:NotNull(message = "The start time is mandatory")
   @Schema(description = "The start time on which to check for overlapping", example = "10:00")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-  val startTime: LocalTime?,
+  val startTime: LocalTime,
 
-  @field:NotNull(message = "The end time is mandatory")
   @Schema(description = "The end time on which to check for overlapping", example = "11:00")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-  val endTime: LocalTime?,
+  val endTime: LocalTime,
 
   @Schema(description = "One or more unique identifier for the prisoner contacts, can be null")
   val contactIds: List<Long>?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/migrate/MigrateVisitConfigRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/migrate/MigrateVisitConfigRequest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.migrate
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.NotBlank
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -13,31 +13,27 @@ import java.util.UUID
 data class MigrateVisitConfigRequest(
 
   @Schema(description = "The 3-letter agy_loc_id from NOMIS where this visit time slot exists", example = "MDI", required = true)
-  @field:NotNull(message = "The prison code for a visit time slot is mandatory")
-  val prisonCode: String?,
+  @field:NotBlank(message = "The prison code for a visit time slot is mandatory")
+  val prisonCode: String,
 
   @Schema(description = "The 3-letter day of the week code where this slot falls in this prison.", example = "TUE", required = true)
-  @field:NotNull(message = "The day code for a visit time slot is mandatory")
-  val dayCode: String?,
+  @field:NotBlank(message = "The day code for a visit time slot is mandatory")
+  val dayCode: String,
 
   @Schema(description = "The time slot sequence in NOMIS. This is used to build a response object for cross-reference", example = "1", required = true)
-  @field:NotNull(message = "The time slot sequence for a visit time slot is mandatory")
-  val timeSlotSeq: Int?,
+  val timeSlotSeq: Int,
 
   @Schema(description = "The start time for this visit time slot", example = "13:30", required = true)
-  @field:NotNull(message = "The start time for a visit time slot is mandatory")
   @JsonFormat(pattern = "HH:mm")
-  val startTime: LocalTime?,
+  val startTime: LocalTime,
 
   @Schema(description = "The end time for this visit time slot", example = "14:30", required = true)
-  @field:NotNull(message = "The end time for a visit time slot is mandatory")
   @JsonFormat(pattern = "HH:mm")
-  val endTime: LocalTime?,
+  val endTime: LocalTime,
 
   @Schema(description = "The date from which this row will be effective", example = "1980-01-01", required = true)
-  @field:NotNull(message = "The effective date for a visit time slot is mandatory")
   @field:DateTimeFormat(pattern = "yyyy-MM-dd")
-  val effectiveDate: LocalDate?,
+  val effectiveDate: LocalDate,
 
   @Schema(description = "The date from which this row will no longer be effective", example = "1980-01-01", nullable = true)
   @field:DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -62,8 +58,7 @@ data class MigrateVisitConfigRequest(
 data class MigrateVisitSlot(
 
   @Schema(description = "Unique ID for this visit slot in NOMIS. For building a response to cross-reference with a DPS visit slot.", example = "1", required = true)
-  @field:NotNull(message = "The visit slot ID is mandatory")
-  val agencyVisitSlotId: Long?,
+  val agencyVisitSlotId: Long,
 
   @Schema(description = "The internal location ID from NOMIS. Information only", example = "1090909", nullable = true)
   val internalLocationId: Long? = null,
@@ -72,8 +67,7 @@ data class MigrateVisitSlot(
   val locationKey: String? = null,
 
   @Schema(description = "The DPS location ID (mapped from the NOMIS internal location ID)", example = "9485cf4a-750b-4d74-b594-59bacbcda247", required = true)
-  @field:NotNull(message = "The DPS location ID for a visit slot is mandatory")
-  val dpsLocationId: UUID?,
+  val dpsLocationId: UUID,
 
   @Schema(description = "The maximum number of groups that can be booked into this visit slot. Effectively, the max visits limit for the slot.", example = "8", nullable = true)
   val maxGroups: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/migrate/MigrateVisitRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/migrate/MigrateVisitRequest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.migrate
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.RelationshipType
@@ -18,52 +17,43 @@ import java.util.UUID
 
 data class MigrateVisitRequest(
   @Schema(description = "The NOMIS offender visit ID", example = "133232", required = true)
-  @field:NotNull(message = "The NOMIS offender visit ID is mandatory")
-  val offenderVisitId: Long?,
+  val offenderVisitId: Long,
 
   @Schema(description = "The DPS visit slot ID - this provides the location, start time and end time via configuration data", example = "123132", required = true)
-  @field:NotNull(message = "The DPS visit slot ID is mandatory")
-  val prisonVisitSlotId: Long?,
+  val prisonVisitSlotId: Long,
 
   @Schema(description = "The prison code where the visit takes place", example = "PVI", required = true)
   @field:NotBlank(message = "The prison code is mandatory")
-  val prisonCode: String?,
+  val prisonCode: String,
 
   @Schema(description = "The offender book ID to echo back. It will be stored in DPS against the visit.", example = "74748", required = true)
-  @field:NotNull(message = "The offender book ID is mandatory")
-  val offenderBookId: Long?,
+  val offenderBookId: Long,
 
   @Schema(description = "The prisoner number (NOMS ID)", example = "A1234AA", required = true)
   @field:NotBlank(message = "The prisoner number for the official visit is mandatory")
   @field:Size(max = 7, message = "Prisoner number must not exceed {max} characters")
-  val prisonerNumber: String?,
+  val prisonerNumber: String,
 
   @Schema(description = "If this visits relates to the current or latest term (booking) in prison true, else false.", example = "true", required = true)
-  @field:NotNull(message = "The current term flag is mandatory")
-  val currentTerm: Boolean?,
+  val currentTerm: Boolean,
 
   @Schema(description = "The date the official visit will take place", example = "2022-12-23", required = true)
-  @field:NotNull(message = "The date for the official visit is mandatory")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd")
-  val visitDate: LocalDate?,
+  val visitDate: LocalDate,
 
   @Schema(description = "The start time for this official visit", example = "09:15", required = true)
-  @field:NotNull(message = "The start time is mandatory")
   @JsonFormat(pattern = "HH:mm")
-  val startTime: LocalTime?,
+  val startTime: LocalTime,
 
   @Schema(description = "The end time for this official visit", example = "10:15", required = true)
-  @field:NotNull(message = "The end time is mandatory")
   @JsonFormat(pattern = "HH:mm")
-  val endTime: LocalTime?,
+  val endTime: LocalTime,
 
   @Schema(description = "The DPS location where the visit takes place.", example = "aaaa-bbbb-xxxxxxxx-yyyyyyyy", required = true)
-  @field:NotNull(message = "The DPS location ID is mandatory")
-  val dpsLocationId: UUID?,
+  val dpsLocationId: UUID,
 
   @Schema(description = "The DPS visit status code. The Syscon migration service will map the NOMIS state to a value in this enumerated type.", example = "SCHEDULED", required = true)
-  @field:NotNull(message = "The visit status code from NOMIS is mandatory")
-  val visitStatusCode: VisitStatusType?,
+  val visitStatusCode: VisitStatusType,
 
   @Schema(description = "The DPS visit type code. For migrated NOMIS visits this will default to type UNKNOWN. Other values are IN_PERSON, VIDEO, or TELEPHONE.", example = "UNKNOWN", nullable = true)
   val visitTypeCode: VisitType? = VisitType.UNKNOWN,
@@ -104,12 +94,10 @@ data class MigrateVisitRequest(
 @Schema(description = "The details of an official visitor")
 data class MigrateVisitor(
   @Schema(description = "The NOMIS offender visit visitor ID", example = "133232", required = true)
-  @field:NotNull(message = "The NOMIS offender visit visitor ID is mandatory")
-  val offenderVisitVisitorId: Long?,
+  val offenderVisitVisitorId: Long,
 
   @Schema(description = "The NOMIS person ID (same as contactId) for this visitor", example = "13989898", required = true)
-  @field:NotNull(message = "The NOMIS person ID is mandatory")
-  val personId: Long?,
+  val personId: Long,
 
   @Schema(description = "The first name of the visitor", example = "Bob", nullable = true)
   val firstName: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/sync/SyncCreateOfficialVisitRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/sync/SyncCreateOfficialVisitRequest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.SearchLevelType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitCompletionType
@@ -16,20 +15,16 @@ import java.util.UUID
 
 data class SyncCreateOfficialVisitRequest(
   @Schema(description = "The NOMIS offender visit ID", example = "133232", required = true)
-  @field:NotNull(message = "The NOMIS offender visit ID is mandatory")
-  var offenderVisitId: Long?,
+  var offenderVisitId: Long,
 
   @Schema(description = "The DPS visit slot ID - this provides the location, start time and end time via configuration data", example = "123132", required = true)
-  @field:NotNull(message = "The DPS visit slot ID is mandatory")
-  var prisonVisitSlotId: Long?,
+  var prisonVisitSlotId: Long,
 
   @Schema(description = "The prison code where the visit takes place", example = "PVI", required = true)
-  @field:NotBlank(message = "The prison code is mandatory")
-  val prisonCode: String?,
+  val prisonCode: String,
 
   @Schema(description = "The offender book ID to echo back. It will be stored in DPS against the visit.", example = "74748", required = true)
-  @field:NotNull(message = "The offender book ID is mandatory")
-  var offenderBookId: Long?,
+  var offenderBookId: Long,
 
   @Schema(description = "The prisoner number (NOMS ID)", example = "A1234AA", required = true)
   @field:NotBlank(message = "The prisoner number for the official visit is mandatory")
@@ -37,31 +32,25 @@ data class SyncCreateOfficialVisitRequest(
   val prisonerNumber: String?,
 
   @Schema(description = "If this visit relates to the current or latest term (booking) in prison true, else false.", example = "true", required = true)
-  @field:NotNull(message = "The current term flag is mandatory")
-  var currentTerm: Boolean? = true,
+  var currentTerm: Boolean = true,
 
   @Schema(description = "The date the official visit will take place", example = "2022-12-23", required = true)
-  @field:NotNull(message = "The date for the official visit is mandatory")
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "uuuu-MM-dd")
-  var visitDate: LocalDate?,
+  var visitDate: LocalDate,
 
   @Schema(description = "The start time for this official visit", example = "09:15", required = true)
-  @field:NotNull(message = "The start time is mandatory")
   @JsonFormat(pattern = "HH:mm")
-  var startTime: LocalTime?,
+  var startTime: LocalTime,
 
   @Schema(description = "The end time for this official visit", example = "10:15", required = true)
-  @field:NotNull(message = "The end time is mandatory")
   @JsonFormat(pattern = "HH:mm")
-  var endTime: LocalTime?,
+  var endTime: LocalTime,
 
   @Schema(description = "The DPS location where the visit takes place.", example = "aaaa-bbbb-xxxxxxxx-yyyyyyyy", required = true)
-  @field:NotNull(message = "The DPS location ID is mandatory")
-  var dpsLocationId: UUID?,
+  var dpsLocationId: UUID,
 
   @Schema(description = "The DPS visit status code. The Syscon sync service will map the NOMIS state to a value in this enumerated type.", example = "SCHEDULED", required = true)
-  @field:NotNull(message = "The visit status code from NOMIS is mandatory")
-  var visitStatusCode: VisitStatusType? = VisitStatusType.SCHEDULED,
+  var visitStatusCode: VisitStatusType = VisitStatusType.SCHEDULED,
 
   @Schema(description = "The DPS visit type code. For sync'd NOMIS visits this will default to type UNKNOWN. Other values are IN_PERSON, VIDEO, or TELEPHONE.", example = "UNKNOWN", nullable = true)
   val visitTypeCode: VisitType? = VisitType.UNKNOWN,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/sync/SyncCreateOfficialVisitorRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/sync/SyncCreateOfficialVisitorRequest.kt
@@ -1,19 +1,17 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.RelationshipType
 import java.time.LocalDateTime
 
 data class SyncCreateOfficialVisitorRequest(
   @Schema(description = "The NOMIS offender visit visitor ID", example = "133232", required = true)
-  @field:NotNull(message = "The NOMIS offender visit visitor ID is mandatory")
-  val offenderVisitVisitorId: Long?,
+  val offenderVisitVisitorId: Long,
 
   @Schema(description = "The NOMIS person ID (same as contactId) for this visitor", example = "13989898", required = true)
-  @field:NotNull(message = "The NOMIS person ID is mandatory")
-  val personId: Long?,
+  val personId: Long,
 
   @Schema(description = "The first name of the visitor", example = "Bob", nullable = true)
   val firstName: String? = null,
@@ -43,5 +41,6 @@ data class SyncCreateOfficialVisitorRequest(
   var createDateTime: LocalDateTime? = null,
 
   @Schema(description = "The username who created the row", example = "X999X", required = true)
-  var createUsername: String? = null,
+  @field:NotBlank("The username cannot be blank")
+  var createUsername: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/sync/SyncUpdateOfficialVisitorRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/sync/SyncUpdateOfficialVisitorRequest.kt
@@ -1,19 +1,16 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.sync
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.RelationshipType
 import java.time.LocalDateTime
 
 data class SyncUpdateOfficialVisitorRequest(
   @Schema(description = "The NOMIS offender visit visitor ID", example = "133232", required = true)
-  @field:NotNull(message = "The NOMIS offender visit visitor ID is mandatory")
-  val offenderVisitVisitorId: Long?,
+  val offenderVisitVisitorId: Long,
 
   @Schema(description = "The NOMIS person ID (same as contactId) for this visitor", example = "13989898", required = true)
-  @field:NotNull(message = "The NOMIS person ID is mandatory")
-  val personId: Long?,
+  val personId: Long,
 
   @Schema(description = "The first name of the visitor", example = "Bob", nullable = true)
   val firstName: String? = null,
@@ -40,10 +37,8 @@ data class SyncUpdateOfficialVisitorRequest(
   val attendanceCode: AttendanceType? = null,
 
   @Schema(description = "The date and time the visitor was updated", example = "2022-10-01T16:45:45", required = true)
-  @field:NotNull(message = "The update date and time is mandatory")
-  var updateDateTime: LocalDateTime? = null,
+  var updateDateTime: LocalDateTime,
 
   @Schema(description = "The username who updated the visitor", example = "X999X", required = true)
-  @field:NotNull(message = "The update username is mandatory")
-  var updateUsername: String? = null,
+  var updateUsername: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCancellationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCancellationService.kt
@@ -38,7 +38,7 @@ class OfficialVisitCancellationService(
     val prisonerVisited = prisonerVisitedRepository.findByOfficialVisit(officialVisit)
       ?: throw EntityNotFoundException("Official visit with id $officialVisitId prisoner not found")
 
-    officialVisit.cancel(request.cancellationReason!!, request.cancellationNotes, user)
+    officialVisit.cancel(request.cancellationReason, request.cancellationNotes, user)
 
     prisonerVisitedRepository.saveAndFlush(
       prisonerVisited.copy(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCompletionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCompletionService.kt
@@ -40,12 +40,12 @@ class OfficialVisitCompletionService(
 
     officialVisitRepository.saveAndFlush(
       officialVisit.complete(
-        completionCode = request.completionReason!!,
+        completionCode = request.completionReason,
         completionNotes = request.completionNotes,
-        prisonerSearchType = request.prisonerSearchType!!,
+        prisonerSearchType = request.prisonerSearchType,
         visitorAttendance = request.visitorAttendance.associateBy(
           { it.officialVisitorId },
-          { it.visitorAttendance!! },
+          { it.visitorAttendance },
         ),
         completedBy = user,
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
@@ -62,12 +62,12 @@ class OfficialVisitCreateService(
       OfficialVisitEntity(
         prisonVisitSlot = prisonVisitSlot,
         prisonCode = prisonCode,
-        prisonerNumber = request.prisonerNumber!!,
-        visitDate = request.visitDate!!,
-        startTime = request.startTime!!,
-        endTime = request.endTime!!,
-        dpsLocationId = request.dpsLocationId!!,
-        visitTypeCode = request.visitTypeCode!!,
+        prisonerNumber = request.prisonerNumber,
+        visitDate = request.visitDate,
+        startTime = request.startTime,
+        endTime = request.endTime,
+        dpsLocationId = request.dpsLocationId,
+        visitTypeCode = request.visitTypeCode,
         staffNotes = request.staffNotes,
         prisonerNotes = request.prisonerNotes,
         offenderBookId = prisonerDetails.bookingId?.toLong(),
@@ -174,16 +174,16 @@ class OfficialVisitCreateService(
   }
 
   private fun CreateOfficialVisitRequest.checkVisitDateAndTimes() = also {
-    require(visitDate!!.atTime(startTime) > now()) { "Official visit cannot be scheduled in the past" }
-    require(startTime!! < endTime) { "Official visit start time must be before end time" }
+    require(visitDate.atTime(startTime) > now()) { "Official visit cannot be scheduled in the past" }
+    require(startTime < endTime) { "Official visit start time must be before end time" }
   }
 
   private fun CreateOfficialVisitRequest.checkStillAvailable(prisonCode: String, prisonVisitSlot: PrisonVisitSlotEntity) = also {
     val availableSlots = availableSlotService.getAvailableSlotsForPrison(
       prisonCode = prisonCode,
-      fromDate = visitDate!!,
+      fromDate = visitDate,
       toDate = visitDate,
-      videoOnly = visitTypeCode!! == VisitType.VIDEO,
+      videoOnly = visitTypeCode == VisitType.VIDEO,
     )
 
     val availableSlotSpecification: AvailableSlotSpecification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(this)
@@ -194,7 +194,7 @@ class OfficialVisitCreateService(
   }
 
   private fun CreateOfficialVisitRequest.getPrisonersDetails(prisonCode: String) = run {
-    prisonerValidator.validatePrisonerAtPrison(prisonerNumber!!, prisonCode)
+    prisonerValidator.validatePrisonerAtPrison(prisonerNumber, prisonCode)
   }
 
   private fun CreateOfficialVisitRequest.getVisitorDetails() = run {
@@ -203,7 +203,7 @@ class OfficialVisitCreateService(
     val requestedVisitors = officialVisitors.filter { it.visitorTypeCode == VisitorType.CONTACT }.toSet()
 
     // This will intentionally allow either active or inactive contacts - as long as they are currentTerm=true and approved=true
-    val approvedVisitors = contactsService.getAllPrisonerContacts(prisonerNumber = prisonerNumber!!, approved = true, currentTerm = true)
+    val approvedVisitors = contactsService.getAllPrisonerContacts(prisonerNumber = prisonerNumber, approved = true, currentTerm = true)
 
     requestedVisitors.map { requestedVisitor ->
       // As we are creating a visit locally in DPS the check for contactId and prisonerContactId is fine here

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitSearchService.kt
@@ -43,13 +43,13 @@ class OfficialVisitSearchService(
   private val metricsService: MetricsService,
 ) {
   fun searchForOfficialVisitSummaries(prisonCode: String, request: OfficialVisitSummarySearchRequest, user: User, page: Int, size: Int): PagedModel<OfficialVisitSummarySearchResponse> = run {
-    require(request.endDate!! >= request.startDate) { "End date must be on or after the start date" }
+    require(request.endDate >= request.startDate) { "End date must be on or after the start date" }
     require(page >= 0) { "Page number must be greater than or equal to zero" }
     require(size > 0) { "Page size must be greater than zero" }
 
     val mayBeSearchTerm = request.searchTerm?.trim()
     require(mayBeSearchTerm == null || mayBeSearchTerm.length >= 2) { "Search term must be a minimum of 2 characters if provided" }
-    val prisoners = mayBeSearchTerm?.let { st -> prisonerSearchClient.findPrisonersBySearchTerm(prisonCode, mayBeSearchTerm) } ?: emptyList()
+    val prisoners = mayBeSearchTerm?.let { prisonerSearchClient.findPrisonersBySearchTerm(prisonCode, mayBeSearchTerm) } ?: emptyList()
 
     // Avoid an unnecessary query if no prisoners found in search above
     if (mayBeSearchTerm != null && prisoners.isEmpty()) {
@@ -59,7 +59,7 @@ class OfficialVisitSearchService(
     val results = officialVisitSummaryRepository.findOfficialVisitSummaryEntityBy(
       prisonCode = prisonCode,
       prisonerNumbers = mayBeSearchTerm?.let { prisoners.map { it.prisonerNumber }.toSet() },
-      startDate = request.startDate!!,
+      startDate = request.startDate,
       endDate = request.endDate,
       visitTypes = request.visitTypes.takeIf { !it.isNullOrEmpty() }?.toSet(),
       visitStatuses = request.visitStatuses.takeIf { !it.isNullOrEmpty() }?.toSet(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitUpdateService.kt
@@ -52,7 +52,7 @@ class OfficialVisitUpdateService(
     val ove = officialVisitRepository.findByOfficialVisitIdAndPrisonCode(officialVisitId, prisonCode)
       ?: throw EntityNotFoundException("Official visit with id $officialVisitId and prison code $prisonCode not found")
 
-    val newPrisonVisitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId!!)
+    val newPrisonVisitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId)
       .orElseThrow { throw ValidationException("Prison visit slot with id ${request.prisonVisitSlotId} not found.") }
 
     val auditChangeEvent = auditVisitChangeEvent {
@@ -74,11 +74,11 @@ class OfficialVisitUpdateService(
 
     val changedOVEntity = ove.apply {
       prisonVisitSlot = newPrisonVisitSlot
-      visitDate = request.visitDate!!
-      startTime = request.startTime!!
-      endTime = request.endTime!!
-      dpsLocationId = request.dpsLocationId!!
-      visitTypeCode = request.visitTypeCode!!
+      visitDate = request.visitDate
+      startTime = request.startTime
+      endTime = request.endTime
+      dpsLocationId = request.dpsLocationId
+      visitTypeCode = request.visitTypeCode
       updatedBy = user.username
       updatedTime = LocalDateTime.now()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OverlappingVisitsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OverlappingVisitsService.kt
@@ -23,16 +23,16 @@ class OverlappingVisitsService(
   }
 
   fun findOverlappingScheduledVisits(prisonCode: String, request: OverlappingVisitsCriteriaRequest): OverlappingVisitsResponse = run {
-    require(request.visitDate!!.atTime(request.startTime!!).isAfter(LocalDateTime.now())) {
+    require(request.visitDate.atTime(request.startTime).isAfter(LocalDateTime.now())) {
       "Cannot overlap visits in the past. Visit date: ${request.visitDate} and start time: ${request.startTime} must be in the future."
     }
 
     val overlappingPrisonerVisits = officialVisitRepository.findScheduledOverlappingVisitsBy(
       prisonCode = prisonCode,
-      prisonerNumber = request.prisonerNumber!!,
+      prisonerNumber = request.prisonerNumber,
       visitDate = request.visitDate,
       startTime = request.startTime,
-      endTime = request.endTime!!,
+      endTime = request.endTime,
     ).ignoring(request.existingOfficialVisitId)
 
     val overlappingContactVisits = buildMap {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrationService.kt
@@ -43,12 +43,12 @@ class MigrationService(
   fun migrateVisitConfiguration(request: MigrateVisitConfigRequest): MigrateVisitConfigResponse {
     logger.info(
       "Migrate time slot in {} day {} timeSlotSeq {} start {} end {} effective {} with {} visit slots",
-      request.prisonCode!!,
-      request.dayCode!!,
-      request.timeSlotSeq!!,
-      request.startTime!!,
-      request.endTime!!,
-      request.effectiveDate!!,
+      request.prisonCode,
+      request.dayCode,
+      request.timeSlotSeq,
+      request.startTime,
+      request.endTime,
+      request.effectiveDate,
       request.visitSlots.size,
     )
 
@@ -80,11 +80,11 @@ class MigrationService(
 
   fun extractAndSaveVisitSlots(timeSlotId: Long, request: MigrateVisitConfigRequest) = request.visitSlots.map { slot ->
     Pair(
-      slot.agencyVisitSlotId!!,
+      slot.agencyVisitSlotId,
       prisonVisitSlotRepository.saveAndFlush(
         PrisonVisitSlotEntity(
           prisonTimeSlotId = timeSlotId,
-          dpsLocationId = slot.dpsLocationId!!,
+          dpsLocationId = slot.dpsLocationId,
           maxAdults = slot.maxAdults,
           maxGroups = slot.maxGroups,
           maxVideoSessions = slot.maxVideoSessions,
@@ -102,15 +102,15 @@ class MigrationService(
     logger.info(
       "Migrate official visit ID {} at {} for {} (bookId {}) on {} with {} visitors",
       request.offenderVisitId,
-      request.prisonCode!!,
-      request.prisonerNumber!!,
+      request.prisonCode,
+      request.prisonerNumber,
       request.offenderBookId,
       request.visitDate,
       request.visitors.size,
     )
 
     // The visit slot must exist prior to related visits being migrated
-    val visitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId!!).orElseThrow {
+    val visitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId).orElseThrow {
       EntityNotFoundException("Prison visit slot ID ${request.prisonVisitSlotId} not found on offender visit ID ${request.offenderVisitId}")
     }
 
@@ -121,15 +121,15 @@ class MigrationService(
     val visitorPairs = extractAndSaveVisitors(visit, request)
 
     return MigrateVisitResponse(
-      visit = IdPair(elementType = ElementType.OFFICIAL_VISIT, nomisId = request.offenderVisitId!!, dpsId = visit.officialVisitId),
-      prisoner = IdPair(elementType = ElementType.PRISONER_VISITED, nomisId = request.offenderBookId!!, dpsId = prisoner.prisonerVisitedId),
+      visit = IdPair(elementType = ElementType.OFFICIAL_VISIT, nomisId = request.offenderVisitId, dpsId = visit.officialVisitId),
+      prisoner = IdPair(elementType = ElementType.PRISONER_VISITED, nomisId = request.offenderBookId, dpsId = prisoner.prisonerVisitedId),
       visitors = visitorPairs.map { IdPair(elementType = ElementType.OFFICIAL_VISITOR, nomisId = it.first, dpsId = it.second.officialVisitorId) },
     )
   }
 
   fun extractAndSaveVisitors(dpsVisit: OfficialVisitEntity, request: MigrateVisitRequest) = request.visitors.map { visitor ->
     Pair(
-      visitor.offenderVisitVisitorId!!,
+      visitor.offenderVisitVisitorId,
       officialVisitorRepository.saveAndFlush(
         OfficialVisitorEntity(
           officialVisit = dpsVisit,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecifications.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.CreateOffici
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.AvailableSlot
 
 object AvailableSlotSpecificationFactory {
-  fun getAvailableSlotSpecification(request: CreateOfficialVisitRequest): AvailableSlotSpecification = when (request.visitTypeCode!!) {
+  fun getAvailableSlotSpecification(request: CreateOfficialVisitRequest): AvailableSlotSpecification = when (request.visitTypeCode) {
     VisitType.IN_PERSON -> InPersonSpecification(request)
     VisitType.VIDEO -> VideoSpecification(request)
     VisitType.TELEPHONE -> TelephoneSpecification(request)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitService.kt
@@ -53,12 +53,12 @@ class SyncOfficialVisitService(
     val createdBy = userService.getUser(request.createUsername!!)
       ?: throw DownstreamServiceException("Cannot retrieve user details for ${request.createUsername}")
 
-    val visitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId!!).orElseThrow {
+    val visitSlot = prisonVisitSlotRepository.findById(request.prisonVisitSlotId).orElseThrow {
       EntityNotFoundException("Prison visit slot ID ${request.prisonVisitSlotId} does not exist")
     }
 
     // When an offenderVisitId is supplied perform a check for duplicates
-    request.offenderVisitId?.let { offenderVisitId ->
+    request.offenderVisitId.let { offenderVisitId ->
       officialVisitRepository.findByOffenderVisitId(offenderVisitId)?.let { duplicate ->
         throw DuplicateOffenderVisitIdConflictException(
           offenderVisitId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sync/SyncOfficialVisitorService.kt
@@ -45,7 +45,7 @@ class SyncOfficialVisitorService(
   }
 
   fun createVisitor(officialVisitId: Long, request: SyncCreateOfficialVisitorRequest): SyncAddVisitorResponse {
-    val createdBy = userService.getUser(request.createUsername!!)
+    val createdBy = userService.getUser(request.createUsername)
       ?: throw DownstreamServiceException("Cannot retrieve user details for ${request.createUsername}")
 
     val visit = officialVisitRepository.findById(officialVisitId).orElseThrow {
@@ -60,7 +60,7 @@ class SyncOfficialVisitorService(
     }
 
     // Get the prisoner contact relationship to check if this person is approved to visit
-    val contactSummary = contactsService.getPrisonerContactSummary(visit.prisonerNumber, request.personId!!)
+    val contactSummary = contactsService.getPrisonerContactSummary(visit.prisonerNumber, request.personId)
     val thisContact = contactSummary.find { it.contactId == request.personId && it.currentTerm }
     if (thisContact != null) {
       if (!thisContact.isApprovedVisitor) {
@@ -83,7 +83,7 @@ class SyncOfficialVisitorService(
         leadVisitor = request.groupLeaderFlag ?: false,
         assistedVisit = request.assistedVisitFlag ?: false,
         visitorNotes = request.commentText,
-        createdBy = request.createUsername ?: "SYNC",
+        createdBy = request.createUsername,
         createdTime = request.createDateTime ?: LocalDateTime.now(),
       ),
     ).also {
@@ -119,8 +119,6 @@ class SyncOfficialVisitorService(
       auditingService.recordAuditEvent(auditChangeEvent)
     }
   }
-
-  private fun OfficialVisitorEntity.name() = "${firstName?.replaceFirstChar { it.uppercase() }} ${lastName?.replaceFirstChar { it.uppercase() }}"
 
   private fun OfficialVisitorEntity.relationshipType() = relationshipTypeCode?.name?.lowercase()?.replaceFirstChar { it.uppercase() }
 
@@ -171,7 +169,7 @@ class SyncOfficialVisitorService(
   }
 
   fun updateVisitor(officialVisitId: Long, officialVisitorId: Long, request: SyncUpdateOfficialVisitorRequest): SyncUpdateVisitorResponse {
-    val updatedByUser = request.updateUsername?.let { userService.getUser(it) }
+    val updatedByUser = request.updateUsername.let { userService.getUser(it) }
       ?: throw DownstreamServiceException("Cannot retrieve user details for ${request.updateUsername}")
 
     val visit = officialVisitRepository.findById(officialVisitId).orElseThrow {
@@ -183,7 +181,7 @@ class SyncOfficialVisitorService(
 
     // Check if the request has changed the person visiting and if so, get their relationship to the prisoner
     val updatedPrisonerContactId = if (visitor.contactId != request.personId) {
-      val contactSummary = contactsService.getPrisonerContactSummary(visit.prisonerNumber, request.personId!!)
+      val contactSummary = contactsService.getPrisonerContactSummary(visit.prisonerNumber, request.personId)
       val thisContact = contactSummary.find { it.contactId == request.personId && it.currentTerm }
       if (thisContact != null) {
         if (!thisContact.isApprovedVisitor) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCancellationRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCancellationRequestTest.kt
@@ -18,7 +18,6 @@ class OfficialVisitCancellationRequestTest : ValidatorBase<OfficialVisitCancella
 
   @Test
   fun `should be errors for invalid requests`() {
-    request.copy(cancellationReason = null) failsWithSingle ModelError("cancellationReason", "The cancellation reason is mandatory")
     request.copy(cancellationNotes = "a".repeat(241)) failsWithSingle ModelError("cancellationNotes", "The cancellation notes should not exceed 240 characters")
 
     VisitCompletionType.entries.filterNot { it.isCancellation }.forEach { reason ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCompletionRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/OfficialVisitCompletionRequestTest.kt
@@ -28,8 +28,6 @@ class OfficialVisitCompletionRequestTest : ValidatorBase<OfficialVisitCompletion
 
   @Test
   fun `should be errors for in valid requests`() {
-    request.copy(completionReason = null) failsWithSingle ModelError("completionReason", "The completion reason is mandatory")
-    request.copy(prisonerAttendance = null) failsWithSingle ModelError("prisonerAttendance", "The prisoner attendance is mandatory")
     request.copy(completionNotes = "a".repeat(241)) failsWithSingle ModelError("completionNotes", "The completion notes should not exceed 240 characters")
 
     VisitCompletionType.entries.filter { it.isCancellation }.forEach { reason ->


### PR DESCRIPTION
This change is needed to help deal with changes to how Open API docs are generated.  Going forwards it will use the field directly and not its annotations.

This means we can no longer have things like nullable fields with the NotNull jakarta annotation.

Note: There are no exception handler changes as this is already picked up in the existing handler [here](https://github.com/ministryofjustice/hmpps-official-visits-api/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/config/OfficialVisitsApiExceptionHandler.kt#L147).

See a more detailed description [here](https://github.com/springdoc/springdoc-openapi/pull/3276).