### PR TITLE
OV-633: Slight tweak to capacity rules. 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotService.kt
@@ -72,12 +72,10 @@ private class AvailableSlotBuilder private constructor(private val timeSource: T
 
   private val datedInPersonVisits = mutableMapOf<DatedVisit, Int>()
   private val datedVideoVisits = mutableMapOf<DatedVisit, Int>()
+  private val datedTelephoneVisits = mutableMapOf<DatedVisit, Int>()
 
   fun add(bookedSlot: VisitBookedEntity) {
     val key = DatedVisit(bookedSlot)
-
-    // TODO: Telephone visits should take 1 off the maxGroups capacity, but ignore the maxAdults limit
-    // TODO: Should we treat telephone visits like video visits and decrement the same capacities?
 
     when {
       bookedSlot.isVisitType(VisitType.IN_PERSON) || bookedSlot.isVisitType(VisitType.UNKNOWN) -> {
@@ -87,6 +85,10 @@ private class AvailableSlotBuilder private constructor(private val timeSource: T
       bookedSlot.isVisitType(VisitType.VIDEO) -> {
         datedVideoVisits.computeIfPresent(key) { _, count -> count + 1 }
         datedVideoVisits.computeIfAbsent(key) { 1 }
+      }
+      bookedSlot.isVisitType(VisitType.TELEPHONE) -> {
+        datedTelephoneVisits.computeIfPresent(key) { _, count -> count + 1 }
+        datedTelephoneVisits.computeIfAbsent(key) { 1 }
       }
     }
   }
@@ -102,7 +104,11 @@ private class AvailableSlotBuilder private constructor(private val timeSource: T
             val availableGroups = availableSlot.availableGroupsOn(date)
             val availableVideoSessions = availableSlot.availableVideoSessionsOn(date)
 
-            if ((availableAdults > 0 && availableGroups > 0 && !videoOnly) || (availableGroups > 0 && availableVideoSessions > 0)) {
+            // Only add the to the list if the slot has some capacity for visits remaining - in person, video or telephone
+            if ((availableAdults > 0 && availableGroups > 0 && !videoOnly) ||
+              (availableGroups > 0 && availableVideoSessions > 0 && videoOnly) ||
+              (availableGroups > 0 && !videoOnly && (availableSlot.maxAdults ?: 0) == 0)
+            ) {
               add(
                 AvailableSlot(
                   visitSlotId = availableSlot.prisonVisitSlotId,
@@ -137,7 +143,7 @@ private class AvailableSlotBuilder private constructor(private val timeSource: T
 
   private fun AvailableSlotEntity.availableAdultsOn(date: LocalDate) = (maxAdults ?: 0) - datedInPersonVisits.individualVisitCount(date, this)
 
-  private fun AvailableSlotEntity.availableGroupsOn(date: LocalDate) = (maxGroups ?: 0) - datedInPersonVisits.groupVisitCount(date, this) - datedVideoVisits.groupVisitCount(date, this)
+  private fun AvailableSlotEntity.availableGroupsOn(date: LocalDate) = (maxGroups ?: 0) - datedInPersonVisits.groupVisitCount(date, this) - datedVideoVisits.groupVisitCount(date, this) - datedTelephoneVisits.groupVisitCount(date, this)
 
   private fun AvailableSlotEntity.availableVideoSessionsOn(date: LocalDate) = (maxVideoSessions ?: 0) - datedVideoVisits.groupVisitCount(date, this)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecifications.kt
@@ -33,6 +33,7 @@ class VideoSpecification(private val request: CreateOfficialVisitRequest) : Avai
     slot.visitSlotId == prisonVisitSlot.prisonVisitSlotId &&
       slot.startTime == request.startTime &&
       slot.dpsLocationId == request.dpsLocationId &&
+      slot.availableGroups > 0 &&
       slot.availableVideoSessions > 0
   }
 }
@@ -42,7 +43,6 @@ class TelephoneSpecification(private val request: CreateOfficialVisitRequest) : 
     slot.visitSlotId == prisonVisitSlot.prisonVisitSlotId &&
       slot.startTime == request.startTime &&
       slot.dpsLocationId == request.dpsLocationId &&
-      slot.availableGroups > 0 &&
-      slot.availableAdults > 0
+      slot.availableGroups > 0
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecificationFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecificationFactoryTest.kt
@@ -105,7 +105,7 @@ class AvailableSlotSpecificationFactoryTest {
     fun `should be available`() {
       val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(videoVisit)
 
-      val availableSlot = availableSlot(availableVideoSessions = 1, availableAdults = 0, availableGroups = 0)
+      val availableSlot = availableSlot(availableVideoSessions = 1, availableAdults = 0, availableGroups = 1)
 
       specification.isSatisfiedBy(availableSlot, prisonVisitSlot) isBool true
     }
@@ -115,6 +115,15 @@ class AvailableSlotSpecificationFactoryTest {
       val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(videoVisit)
 
       val availableSlot = availableSlot(availableVideoSessions = 0, availableAdults = 1, availableGroups = 1)
+
+      specification.isSatisfiedBy(availableSlot, prisonVisitSlot) isBool false
+    }
+
+    @Test
+    fun `should not be available when exceeds available groups despite video sessions available`() {
+      val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(videoVisit)
+
+      val availableSlot = availableSlot(availableVideoSessions = 1, availableAdults = 0, availableGroups = 0)
 
       specification.isSatisfiedBy(availableSlot, prisonVisitSlot) isBool false
     }
@@ -133,16 +142,25 @@ class AvailableSlotSpecificationFactoryTest {
     fun `should be available`() {
       val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(telephoneVisit)
 
-      val availableSlot = availableSlot(availableVideoSessions = 1, availableAdults = 1, availableGroups = 1)
+      val availableSlot = availableSlot(availableVideoSessions = 1, availableAdults = 0, availableGroups = 1)
 
       specification.isSatisfiedBy(availableSlot, prisonVisitSlot) isBool true
     }
 
     @Test
-    fun `should not be available when no available adults or groups `() {
+    fun `should not be available when no available groups `() {
       val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(telephoneVisit)
 
       val availableSlot = availableSlot(availableVideoSessions = 1, availableAdults = 0, availableGroups = 0)
+
+      specification.isSatisfiedBy(availableSlot, prisonVisitSlot) isBool false
+    }
+
+    @Test
+    fun `should not be even if available adults allows - its the groups that count for telephone visits `() {
+      val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(telephoneVisit)
+
+      val availableSlot = availableSlot(availableVideoSessions = 0, availableAdults = 10, availableGroups = 0)
 
       specification.isSatisfiedBy(availableSlot, prisonVisitSlot) isBool false
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecificationFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/slotavailability/AvailableSlotSpecificationFactoryTest.kt
@@ -148,7 +148,7 @@ class AvailableSlotSpecificationFactoryTest {
     }
 
     @Test
-    fun `should not be available when no available groups `() {
+    fun `should not be available when no available group capacity`() {
       val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(telephoneVisit)
 
       val availableSlot = availableSlot(availableVideoSessions = 1, availableAdults = 0, availableGroups = 0)
@@ -157,7 +157,7 @@ class AvailableSlotSpecificationFactoryTest {
     }
 
     @Test
-    fun `should not be even if available adults allows - its the groups that count for telephone visits `() {
+    fun `should not be available even where adult capacity allows - only the groups count for telephone visits `() {
       val specification = AvailableSlotSpecificationFactory.getAvailableSlotSpecification(telephoneVisit)
 
       val availableSlot = availableSlot(availableVideoSessions = 0, availableAdults = 10, availableGroups = 0)


### PR DESCRIPTION
Telephone visit capacity is reliant on the maxGroups limits only, and does not check the maxAdults (visitors are remote)
Video visit capacity is reliant on both the maxVideo and the maxGroups limits - updating to match guidance given to prisons.