### PR TITLE
OV-729 : API endpoint to return the notifications sent for an official visit by ID.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationFacade.kt
@@ -5,9 +5,9 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitNotification
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.User
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.Email
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.notifications.NotificationsService
 
 @Service
@@ -25,5 +25,5 @@ class NotificationFacade(
     user: User,
   ): PagedModel<SentEmailRecord> = notificationsService.searchSentEmails(prisonCode, criteria, page, size, user)
 
-  fun sendOfficialVisitEmail(officialVisitId: Long, email: Email): Long? = notificationsService.sendOfficialVisitEmail(officialVisitId, email)
+  fun getNotificationsByOfficialVisitId(officialVisitId: Long): List<OfficialVisitNotification> = notificationsService.getNotificationsByOfficialVisitId(officialVisitId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/notifications/NotificationFacade.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications
 
+import org.springframework.data.domain.Sort
 import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
@@ -25,5 +26,8 @@ class NotificationFacade(
     user: User,
   ): PagedModel<SentEmailRecord> = notificationsService.searchSentEmails(prisonCode, criteria, page, size, user)
 
-  fun getNotificationsByOfficialVisitId(officialVisitId: Long): List<OfficialVisitNotification> = notificationsService.getNotificationsByOfficialVisitId(officialVisitId)
+  fun getNotificationsByOfficialVisitId(officialVisitId: Long, sort: Sort): List<OfficialVisitNotification> = notificationsService.getNotificationsByOfficialVisitId(
+    officialVisitId,
+    sort,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/OfficialVisitNotification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/OfficialVisitNotification.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEmailStatus
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class OfficialVisitNotification(
+  @Schema(description = "The notification id", example = "1")
+  val notificationId: Long,
+  @Schema(description = "The official visit id", example = "1")
+  val officialVisitId: Long,
+  @Schema(description = "The template id", example = "1")
+  val templateId: String,
+  @Schema(description = "The email address", example = "")
+  val emailAddress: String,
+  @Schema(description = "The reason", example = "")
+  val reason: String,
+  @Schema(description = "The gov notify notification id", example = "")
+  val govNotifyNotificationId: UUID,
+  @Schema(description = "The email status", example = "")
+  val emailStatus: NotificationEmailStatus,
+  @Schema(description = "The created time", example = "")
+  val createdTime: LocalDateTime,
+  @Schema(description = "The status updated time", example = "")
+  val statusUpdatedTime: LocalDateTime?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/OfficialVisitNotification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/OfficialVisitNotification.kt
@@ -12,16 +12,16 @@ data class OfficialVisitNotification(
   val officialVisitId: Long,
   @Schema(description = "The template id", example = "1")
   val templateId: String,
-  @Schema(description = "The email address", example = "")
+  @Schema(description = "The email address", example = "exmple@example.com")
   val emailAddress: String,
-  @Schema(description = "The reason", example = "")
+  @Schema(description = "The reason", example = "the reason")
   val reason: String,
-  @Schema(description = "The gov notify notification id", example = "")
+  @Schema(description = "The gov notify notification id", example = "12345678-1234-1234-1234-123456789012")
   val govNotifyNotificationId: UUID,
-  @Schema(description = "The email status", example = "")
+  @Schema(description = "The email status", example = "SENT")
   val emailStatus: NotificationEmailStatus,
-  @Schema(description = "The created time", example = "")
+  @Schema(description = "The created time", example = "09:00")
   val createdTime: LocalDateTime,
-  @Schema(description = "The status updated time", example = "")
+  @Schema(description = "The status updated time", example = "10:00")
   val statusUpdatedTime: LocalDateTime?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/NotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/NotificationRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.repository
 
+import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEntity
@@ -11,5 +12,5 @@ interface NotificationRepository : JpaRepository<NotificationEntity, Long> {
 
   fun findTopByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId: Long): NotificationEntity?
 
-  fun findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId: Long): List<NotificationEntity>
+  fun findByOfficialVisitId(officialVisitId: Long, sort: Sort): List<NotificationEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/NotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/NotificationRepository.kt
@@ -10,4 +10,6 @@ interface NotificationRepository : JpaRepository<NotificationEntity, Long> {
   fun findByGovNotifyNotificationId(govNotifyNotificationId: UUID): NotificationEntity?
 
   fun findTopByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId: Long): NotificationEntity?
+
+  fun findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId: Long): List<NotificationEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Sort
 import org.springframework.data.domain.Sort.Direction
 import org.springframework.data.domain.Sort.Direction.ASC
-import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
@@ -51,13 +50,13 @@ class OfficialVisitNotificationsController(
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__R', 'ROLE_OFFICIAL_VISITS_RW')")
   fun getNotificationsByOfficialVisitId(
-      @PathVariable @Parameter(
+    @PathVariable @Parameter(
       name = "officialVisitId",
       description = "The official visit identifier",
       example = "1",
       required = true,
     ) officialVisitId: Long,
-      @RequestParam(defaultValue = "ASC")
+    @RequestParam(defaultValue = "ASC")
     @Parameter(description = "Sort results by created time desc or asc, default to ASC", required = false)
     sortDirection: Direction = ASC,
   ): List<OfficialVisitNotification> = notificationFacade.getNotificationsByOfficialVisitId(officialVisitId, sort = Sort.by(sortDirection, "createdTime"))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
@@ -8,12 +8,16 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction
+import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationFacade
@@ -52,5 +56,8 @@ class OfficialVisitNotificationsController(
       example = "1",
       required = true,
     ) officialVisitId: Long,
-  ): List<OfficialVisitNotification> = notificationFacade.getNotificationsByOfficialVisitId(officialVisitId)
+    @RequestParam(defaultValue = "DESC")
+    @Parameter(description = "Sort results by created time desc or asc, default to DESC", required = false)
+    sortDirection: Direction = DESC,
+  ): List<OfficialVisitNotification> = notificationFacade.getNotificationsByOfficialVisitId(officialVisitId, sort = Sort.by(sortDirection, "createdTime"))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Sort
 import org.springframework.data.domain.Sort.Direction
+import org.springframework.data.domain.Sort.Direction.ASC
 import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -50,14 +51,14 @@ class OfficialVisitNotificationsController(
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__R', 'ROLE_OFFICIAL_VISITS_RW')")
   fun getNotificationsByOfficialVisitId(
-    @PathVariable @Parameter(
+      @PathVariable @Parameter(
       name = "officialVisitId",
       description = "The official visit identifier",
       example = "1",
       required = true,
     ) officialVisitId: Long,
-    @RequestParam(defaultValue = "DESC")
-    @Parameter(description = "Sort results by created time desc or asc, default to DESC", required = false)
-    sortDirection: Direction = DESC,
+      @RequestParam(defaultValue = "ASC")
+    @Parameter(description = "Sort results by created time desc or asc, default to ASC", required = false)
+    sortDirection: Direction = ASC,
   ): List<OfficialVisitNotification> = notificationFacade.getNotificationsByOfficialVisitId(officialVisitId, sort = Sort.by(sortDirection, "createdTime"))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -35,7 +36,7 @@ class OfficialVisitNotificationsController(
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = OfficialVisitNotification::class),
+            array = ArraySchema(schema = Schema(implementation = OfficialVisitNotification::class)),
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitNotificationsController.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.officialvisitsapi.facade.notifications.NotificationFacade
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitNotification
+
+@Tag(name = "Official visit notifications")
+@RestController
+@RequestMapping(value = ["official-visit"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@AuthApiResponses
+class OfficialVisitNotificationsController(
+  private val notificationFacade: NotificationFacade,
+) {
+
+  @Operation(summary = "Get all notifications sent for an official visit ID.")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "A list of notification rows for the official visit",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = OfficialVisitNotification::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @GetMapping(path = ["/id/{officialVisitId}/notifications"])
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__R', 'ROLE_OFFICIAL_VISITS_RW')")
+  fun getNotificationsByOfficialVisitId(
+    @PathVariable @Parameter(
+      name = "officialVisitId",
+      description = "The official visit identifier",
+      example = "1",
+      required = true,
+    ) officialVisitId: Long,
+  ): List<OfficialVisitNotification> = notificationFacade.getNotificationsByOfficialVisitId(officialVisitId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.service.notifications
 
 import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Sort
 import org.springframework.data.web.PagedModel
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -70,10 +71,10 @@ class NotificationsService(
     user: User,
   ): PagedModel<SentEmailRecord> = sentEmailsService.searchSentEmails(prisonCode, criteria, page, size, user)
 
-  fun getNotificationsByOfficialVisitId(officialVisitId: Long): List<OfficialVisitNotification> = run {
+  fun getNotificationsByOfficialVisitId(officialVisitId: Long, sort: Sort): List<OfficialVisitNotification> = run {
     officialVisitRepository.findById(officialVisitId)
       .orElseThrow { EntityNotFoundException("Official visit with id $officialVisitId not found") }
-    notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId)
+    notificationRepository.findByOfficialVisitId(officialVisitId, sort)
       .map { it.toOfficialVisitNotification() }
   }
 
@@ -83,7 +84,7 @@ class NotificationsService(
   @Transactional
   fun sendOfficialVisitEmail(officialVisitId: Long, email: Email): Long? = run {
     var notificationId: Long? = null
-
+    logger.info("sending email ${email.type()} officialVisitId $officialVisitId and emailAddress ${email.emailAddress}.")
     emailService.send(email)
       .onSuccess { (govNotifyNotificationId, templateId) ->
         notificationRepository.saveAndFlush(
@@ -96,7 +97,10 @@ class NotificationsService(
             emailStatus = NotificationEmailStatus.PENDING,
             createdTime = LocalDateTime.now(),
           ),
-        ).also { notificationId = it.notificationId }
+        ).also {
+          notificationId = it.notificationId
+          logger.info("sent notification with notification id $notificationId and emailAddress ${email.emailAddress}.")
+        }
       }
       .onFailure { exception -> logger.info("Failed to send email ${email.type()}.", exception) }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
@@ -47,7 +47,8 @@ class NotificationsService(
       .orElseThrow { EntityNotFoundException("Official visit with id $officialVisitId not found") }
 
     val location = locationsService.getLocationById(officialVisit.dpsLocationId)?.localName ?: "Unknown location"
-    val prisoner = prisonerSearchClient.getPrisoner(officialVisit.prisonerNumber) ?: throw EntityNotFoundException("Prisoner not found ${officialVisit.prisonerNumber}")
+    val prisoner = prisonerSearchClient.getPrisoner(officialVisit.prisonerNumber)
+      ?: throw EntityNotFoundException("Prisoner not found ${officialVisit.prisonerNumber}")
 
     val recipients = buildSet {
       request.emailAddresses.distinct().forEach { emailAddress ->
@@ -61,9 +62,20 @@ class NotificationsService(
     NotificationResponse(officialVisitId, request.notificationType, recipients.toList())
   }
 
-  fun searchSentEmails(prisonCode: String, criteria: SentEmailSearchCriteria, page: Int, size: Int, user: User): PagedModel<SentEmailRecord> = sentEmailsService.searchSentEmails(prisonCode, criteria, page, size, user)
+  fun searchSentEmails(
+    prisonCode: String,
+    criteria: SentEmailSearchCriteria,
+    page: Int,
+    size: Int,
+    user: User,
+  ): PagedModel<SentEmailRecord> = sentEmailsService.searchSentEmails(prisonCode, criteria, page, size, user)
 
-  fun getNotificationsByOfficialVisitId(officialVisitId: Long): List<OfficialVisitNotification> = notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId).map { it.toOfficialVisitNotification() }
+  fun getNotificationsByOfficialVisitId(officialVisitId: Long): List<OfficialVisitNotification> = run {
+    officialVisitRepository.findById(officialVisitId)
+      .orElseThrow { EntityNotFoundException("Official visit with id $officialVisitId not found") }
+    notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId)
+      .map { it.toOfficialVisitNotification() }
+  }
 
   /**
    * Will return the identifier of the notification created if successful, otherwise null.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
@@ -99,7 +99,7 @@ class NotificationsService(
           ),
         ).also {
           notificationId = it.notificationId
-          logger.info("sent notification with notification id $notificationId and emailAddress ${email.emailAddress}.")
+          logger.info("sent notification with notification id $notificationId.")
         }
       }
       .onFailure { exception -> logger.info("Failed to send email ${email.type()}.", exception) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
@@ -84,7 +84,7 @@ class NotificationsService(
   @Transactional
   fun sendOfficialVisitEmail(officialVisitId: Long, email: Email): Long? = run {
     var notificationId: Long? = null
-    logger.info("sending email ${email.type()} officialVisitId $officialVisitId and emailAddress ${email.emailAddress}.")
+    logger.info("sending email ${email.type()} officialVisitId $officialVisitId")
     emailService.send(email)
       .onSuccess { (govNotifyNotificationId, templateId) ->
         notificationRepository.saveAndFlush(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.Notification
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationRecipient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitNotification
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
@@ -61,6 +62,8 @@ class NotificationsService(
   }
 
   fun searchSentEmails(prisonCode: String, criteria: SentEmailSearchCriteria, page: Int, size: Int, user: User): PagedModel<SentEmailRecord> = sentEmailsService.searchSentEmails(prisonCode, criteria, page, size, user)
+
+  fun getNotificationsByOfficialVisitId(officialVisitId: Long): List<OfficialVisitNotification> = notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId).map { it.toOfficialVisitNotification() }
 
   /**
    * Will return the identifier of the notification created if successful, otherwise null.
@@ -126,6 +129,18 @@ class NotificationsService(
       )
     }
   }
+
+  private fun NotificationEntity.toOfficialVisitNotification() = OfficialVisitNotification(
+    notificationId = notificationId,
+    officialVisitId = officialVisitId,
+    templateId = templateId,
+    emailAddress = emailAddress,
+    reason = reason,
+    govNotifyNotificationId = govNotifyNotificationId,
+    emailStatus = emailStatus,
+    createdTime = createdTime,
+    statusUpdatedTime = statusUpdatedTime,
+  )
 }
 
 enum class NotificationType {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/TestApiClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/helper/TestApiClient.kt
@@ -3,11 +3,13 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.helper
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.CreateOfficialVisitRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitCancellationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitCompletionRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.CreateOfficialVisitResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitDetails
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.notifications.NotificationType
@@ -68,6 +70,9 @@ class TestApiClient(private val webTestClient: WebTestClient, private val jwtAut
     .headers(setAuthorisation(prisonUser, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
     .exchange()
     .expectStatus().isCreated
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody<NotificationResponse>()
+    .returnResult().responseBody!!
 
   private fun setAuthorisation(prisonUser: PrisonUser, roles: List<String>): (HttpHeaders) -> Unit = run {
     jwtAuthHelper.setAuthorisationHeader(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationsIntegrationTest.kt
@@ -26,12 +26,10 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.SentEmailSearchCriteria
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationRecipient
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.SentEmailRecord
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsEvents
@@ -100,12 +98,10 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
   fun `should send single create visit notification`() {
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    val response = webTestClient.send(
+    val response = testAPIClient.sendNotification(
       officialVisitId = scheduledVisit.officialVisitId,
-      request = NotificationRequest(
-        notificationType = NotificationType.CREATE,
-        emailAddresses = listOf("email@address.com"),
-      ),
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email@address.com"),
     )
 
     val notification = notificationRepository.findAll().single()
@@ -128,12 +124,10 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
   fun `should send multiple create visit notifications`() {
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    val response = webTestClient.send(
+    val response = testAPIClient.sendNotification(
       officialVisitId = scheduledVisit.officialVisitId,
-      request = NotificationRequest(
-        notificationType = NotificationType.CREATE,
-        emailAddresses = listOf("email1@address.com", "email2s@address.com"),
-      ),
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email1@address.com", "email2s@address.com"),
     )
 
     val notificationRecipients = notificationRepository.findAll().map { NotificationRecipient(it.emailAddress, it.notificationId) }
@@ -150,12 +144,10 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
     // Create a visit and send a notification
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    webTestClient.send(
+    testAPIClient.sendNotification(
       officialVisitId = scheduledVisit.officialVisitId,
-      request = NotificationRequest(
-        notificationType = NotificationType.CREATE,
-        emailAddresses = listOf("email@address.com"),
-      ),
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email@address.com"),
     )
 
     // Search for sent emails
@@ -193,12 +185,10 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
     // Create a visit and send a notification
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    webTestClient.send(
+    testAPIClient.sendNotification(
       officialVisitId = scheduledVisit.officialVisitId,
-      request = NotificationRequest(
-        notificationType = NotificationType.CREATE,
-        emailAddresses = listOf("email@address.com"),
-      ),
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email@address.com"),
     )
 
     // Search with matching date range
@@ -234,12 +224,10 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
   fun `should include records when from and to dates are the same day`() {
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    webTestClient.send(
+    testAPIClient.sendNotification(
       officialVisitId = scheduledVisit.officialVisitId,
-      request = NotificationRequest(
-        notificationType = NotificationType.CREATE,
-        emailAddresses = listOf("email@address.com"),
-      ),
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email@address.com"),
     )
 
     val today = LocalDate.now()
@@ -258,12 +246,10 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
   fun `should return no sent emails for a different prison code`() {
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    webTestClient.send(
+    testAPIClient.sendNotification(
       officialVisitId = scheduledVisit.officialVisitId,
-      request = NotificationRequest(
-        notificationType = NotificationType.CREATE,
-        emailAddresses = listOf("email@address.com"),
-      ),
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email@address.com"),
     )
 
     val result = webTestClient.searchSentEmails(
@@ -276,18 +262,6 @@ class NotificationsIntegrationTest : IntegrationTestBase() {
     result.page.totalElements isEqualTo 0L
     result.content.isEmpty()
   }
-
-  private fun WebTestClient.send(officialVisitId: Long, request: NotificationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
-    .post()
-    .uri("/notification/$officialVisitId")
-    .bodyValue(request)
-    .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
-    .exchange()
-    .expectStatus().isCreated
-    .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody<NotificationResponse>()
-    .returnResult().responseBody!!
 
   private fun WebTestClient.searchSentEmails(
     prisonCode: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitNotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitNotificationsIntegrationTest.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.integration.resource
-
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
@@ -21,10 +21,8 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitNotification
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
@@ -90,15 +88,16 @@ class OfficialVisitNotificationsIntegrationTest : IntegrationTestBase() {
   fun `should return notifications for an official visit id`() {
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    webTestClient.send(
+    testAPIClient.sendNotification(
       officialVisitId = scheduledVisit.officialVisitId,
-      request = NotificationRequest(
-        notificationType = NotificationType.CREATE,
-        emailAddresses = listOf("email@address.com", "email2@address.com"),
-      ),
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email@address.com", "email2@address.com"),
     )
 
-    val notifications = webTestClient.getNotificationsByOfficialVisitId(scheduledVisit.officialVisitId)
+    val notifications = webTestClient.getNotificationsByOfficialVisitId(
+      scheduledVisit.officialVisitId,
+      sort = "sortDirection=ASC",
+    )
 
     notifications.size isEqualTo 2
     notifications.map { it.officialVisitId }.distinct() containsExactly listOf(scheduledVisit.officialVisitId)
@@ -107,10 +106,52 @@ class OfficialVisitNotificationsIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return notifications for an official visit id with sort ascending or descending`() {
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    val older = testAPIClient.sendNotification(
+      officialVisitId = scheduledVisit.officialVisitId,
+      notificationType = NotificationType.CREATE,
+      emailAddresses = listOf("email@address.com", "email2@address.com"),
+    )
+
+    val newer = testAPIClient.sendNotification(
+      officialVisitId = scheduledVisit.officialVisitId,
+      notificationType = NotificationType.AMEND,
+      emailAddresses = listOf("email@address.com"),
+    )
+
+    val resultDesc = webTestClient.getNotificationsByOfficialVisitId(
+      scheduledVisit.officialVisitId,
+      sort = "sortDirection=DESC",
+    ).map { it.notificationId }
+
+    assertThat(resultDesc).containsExactly(
+      newer.recipients.first().notificationId,
+      older.recipients.last().notificationId,
+      older.recipients.first().notificationId,
+    )
+
+    val resultAsc = webTestClient.getNotificationsByOfficialVisitId(
+      scheduledVisit.officialVisitId,
+      sort = "sortDirection=ASC",
+    ).map { it.notificationId }
+
+    assertThat(resultAsc).containsExactly(
+      older.recipients.first().notificationId,
+      older.recipients.last().notificationId,
+      newer.recipients.first().notificationId,
+    )
+  }
+
+  @Test
   fun `should return empty notifications list when none exist for official visit id`() {
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
-    val notifications = webTestClient.getNotificationsByOfficialVisitId(scheduledVisit.officialVisitId)
+    val notifications = webTestClient.getNotificationsByOfficialVisitId(
+      scheduledVisit.officialVisitId,
+      sort = "sortDirection=ASC",
+    )
 
     notifications.isEmpty() isBool true
   }
@@ -120,24 +161,13 @@ class OfficialVisitNotificationsIntegrationTest : IntegrationTestBase() {
     webTestClient.getNotificationsByOfficialVisitIdNotFound(999L)
   }
 
-  private fun WebTestClient.send(officialVisitId: Long, request: NotificationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
-    .post()
-    .uri("/notification/$officialVisitId")
-    .bodyValue(request)
-    .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
-    .exchange()
-    .expectStatus().isCreated
-    .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody<NotificationResponse>()
-    .returnResult().responseBody!!
-
   private fun WebTestClient.getNotificationsByOfficialVisitId(
     officialVisitId: Long,
     prisonUser: PrisonUser = MOORLAND_PRISON_USER,
+    sort: String,
   ) = this
     .get()
-    .uri("/official-visit/id/$officialVisitId/notifications")
+    .uri("/official-visit/id/$officialVisitId/notifications?$sort")
     .accept(MediaType.APPLICATION_JSON)
     .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
     .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitNotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitNotificationsIntegrationTest.kt
@@ -1,0 +1,142 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.integration.resource
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactly
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createOfficialVisitRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
+import uk.gov.justice.digital.hmpps.officialvisitsapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitorType
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotificationRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.VisitorEquipment
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.NotificationResponse
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitNotification
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PrisonUser
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.metrics.MetricsService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.notifications.NotificationType
+import java.util.UUID
+
+class OfficialVisitNotificationsIntegrationTest : IntegrationTestBase() {
+
+  @MockitoBean
+  private lateinit var metricsService: MetricsService
+
+  private val location = moorlandLocation.copy(id = UUID.fromString("9485cf4a-750b-4d74-b594-59bacbcda247"))
+
+  private val officialVisitor = OfficialVisitor(
+    visitorTypeCode = VisitorType.CONTACT,
+    relationshipCode = "POM",
+    contactId = 123,
+    prisonerContactId = 456,
+    leadVisitor = true,
+    assistedVisit = false,
+    assistedNotes = "visitor notes",
+    visitorEquipment = VisitorEquipment("Bringing secure laptop"),
+  )
+
+  private val nextMondayAt9 = createOfficialVisitRequest(Moorland.MONDAY_9_TO_10_VISIT_SLOT, listOf(officialVisitor))
+
+  @BeforeEach
+  @Transactional
+  fun setupTest() {
+    clearAllVisitData()
+
+    locationsInsidePrisonApi().stubGetLocationById(location)
+    locationsInsidePrisonApi().stubGetOfficialVisitLocationsAtPrison(MOORLAND, locations = listOf(location))
+
+    // Stub a known contact
+    personalRelationshipsApi().stubAllContacts(
+      prisonerNumber = MOORLAND_PRISONER.number,
+      prisonerContacts = listOf(
+        prisonerContact(
+          prisonerNumber = MOORLAND_PRISONER.number,
+          type = "O",
+          contactId = officialVisitor.contactId!!,
+          prisonerContactId = officialVisitor.prisonerContactId!!,
+        ),
+      ),
+    )
+
+    prisonerSearchApi().stubSearchPrisonersByPrisonerNumbers(
+      idsBeingSearchFor = listOf(MOORLAND_PRISONER.number),
+      prisonersToReturn = listOf(
+        prisonerSearchPrisoner(
+          prisonerNumber = MOORLAND_PRISONER.number,
+          prisonCode = MOORLAND,
+          firstName = MOORLAND_PRISONER.firstName,
+          lastName = MOORLAND_PRISONER.lastName,
+          bookingId = MOORLAND_PRISONER.bookingId,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun `should return notifications for an official visit id`() {
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    webTestClient.send(
+      officialVisitId = scheduledVisit.officialVisitId,
+      request = NotificationRequest(
+        notificationType = NotificationType.CREATE,
+        emailAddresses = listOf("email@address.com", "email2@address.com"),
+      ),
+    )
+
+    val notifications = webTestClient.getNotificationsByOfficialVisitId(scheduledVisit.officialVisitId)
+
+    notifications.size isEqualTo 2
+    notifications.map { it.officialVisitId }.distinct() containsExactly listOf(scheduledVisit.officialVisitId)
+    notifications.map { it.emailAddress } containsExactlyInAnyOrder listOf("email@address.com", "email2@address.com")
+    notifications.map { it.reason }.distinct() containsExactly listOf("OFFICIAL_VISIT_CREATED")
+  }
+
+  @Test
+  fun `should return empty notifications list when none exist for official visit id`() {
+    val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
+
+    val notifications = webTestClient.getNotificationsByOfficialVisitId(scheduledVisit.officialVisitId)
+
+    notifications.isEmpty() isEqualTo true
+  }
+
+  private fun WebTestClient.send(officialVisitId: Long, request: NotificationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
+    .post()
+    .uri("/notification/$officialVisitId")
+    .bodyValue(request)
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
+    .exchange()
+    .expectStatus().isCreated
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody<NotificationResponse>()
+    .returnResult().responseBody!!
+
+  private fun WebTestClient.getNotificationsByOfficialVisitId(
+    officialVisitId: Long,
+    prisonUser: PrisonUser = MOORLAND_PRISON_USER,
+  ) = this
+    .get()
+    .uri("/official-visit/id/$officialVisitId/notifications")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
+    .exchange()
+    .expectStatus().isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody<List<OfficialVisitNotification>>()
+    .returnResult().responseBody!!
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitNotificationsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitNotificationsIntegrationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.Moorland
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactly
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createOfficialVisitRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isBool
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.isEqualTo
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.moorlandLocation
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerContact
@@ -111,7 +112,12 @@ class OfficialVisitNotificationsIntegrationTest : IntegrationTestBase() {
 
     val notifications = webTestClient.getNotificationsByOfficialVisitId(scheduledVisit.officialVisitId)
 
-    notifications.isEmpty() isEqualTo true
+    notifications.isEmpty() isBool true
+  }
+
+  @Test
+  fun `should return 404 when no visit exists for id`() {
+    webTestClient.getNotificationsByOfficialVisitIdNotFound(999L)
   }
 
   private fun WebTestClient.send(officialVisitId: Long, request: NotificationRequest, prisonUser: PrisonUser = MOORLAND_PRISON_USER) = this
@@ -139,4 +145,17 @@ class OfficialVisitNotificationsIntegrationTest : IntegrationTestBase() {
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody<List<OfficialVisitNotification>>()
     .returnResult().responseBody!!
+
+  private fun WebTestClient.getNotificationsByOfficialVisitIdNotFound(
+    officialVisitId: Long,
+    prisonUser: PrisonUser = MOORLAND_PRISON_USER,
+  ) = this
+    .get()
+    .uri("/official-visit/id/$officialVisitId/notifications")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
+    .exchange()
+    .expectStatus().isNotFound
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody().jsonPath("$.userMessage").isEqualTo("Official visit with id $officialVisitId not found")
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrateVisitServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/migrate/MigrateVisitServiceTest.kt
@@ -123,7 +123,7 @@ class MigrateVisitServiceTest {
           .extracting("prisonCode", "dayCode", "startTime", "endTime", "effectiveDate", "expiryDate", "createdBy", "createdTime")
           .contains(
             request.prisonCode,
-            DayType.valueOf(request.dayCode!!),
+            DayType.valueOf(request.dayCode),
             request.startTime,
             request.endTime,
             request.effectiveDate,
@@ -237,7 +237,7 @@ class MigrateVisitServiceTest {
       PrisonVisitSlotEntity(
         prisonVisitSlotId = 1L,
         prisonTimeSlotId = 1L,
-        dpsLocationId = request.visitSlots[0].dpsLocationId!!,
+        dpsLocationId = request.visitSlots[0].dpsLocationId,
         maxAdults = request.visitSlots[0].maxAdults,
         maxGroups = request.visitSlots[0].maxGroups,
         maxVideoSessions = request.visitSlots[0].maxVideoSessions,
@@ -247,7 +247,7 @@ class MigrateVisitServiceTest {
       PrisonVisitSlotEntity(
         prisonVisitSlotId = 2L,
         prisonTimeSlotId = 1L,
-        dpsLocationId = request.visitSlots[1].dpsLocationId!!,
+        dpsLocationId = request.visitSlots[1].dpsLocationId,
         maxAdults = request.visitSlots[1].maxAdults,
         maxGroups = request.visitSlots[1].maxGroups,
         maxVideoSessions = request.visitSlots[1].maxVideoSessions,
@@ -400,7 +400,7 @@ class MigrateVisitServiceTest {
     private fun prisonerVisitedEntity(request: MigrateVisitRequest, visit: OfficialVisitEntity) = PrisonerVisitedEntity(
       prisonerVisitedId = 1L,
       officialVisit = visit,
-      prisonerNumber = request.prisonerNumber!!,
+      prisonerNumber = request.prisonerNumber,
       createdBy = aUsername,
       createdTime = aDateTime,
     )
@@ -421,7 +421,7 @@ class MigrateVisitServiceTest {
         visitorNotes = request.visitors[0].commentText,
         createdBy = aUsername,
         createdTime = aDateTime,
-        offenderVisitVisitorId = request.visitors[0].offenderVisitVisitorId!!,
+        offenderVisitVisitorId = request.visitors[0].offenderVisitVisitorId,
       ).apply {
         attendanceCode = request.visitors[0].attendanceCode
       },
@@ -440,7 +440,7 @@ class MigrateVisitServiceTest {
         visitorNotes = request.visitors[1].commentText,
         createdBy = aUsername,
         createdTime = aDateTime,
-        offenderVisitVisitorId = request.visitors[1].offenderVisitVisitorId!!,
+        offenderVisitVisitorId = request.visitors[1].offenderVisitVisitorId,
       ).apply {
         attendanceCode = request.visitors[1].attendanceCode
       },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toMediumFormatStyle
@@ -218,9 +219,9 @@ class NotificationsServiceTest {
       statusUpdatedTime = statusUpdatedTime,
     )
     whenever { officialVisitRepository.findById(999L) } doReturn Optional.of(createAVisitEntity(999L))
-    whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(999L) } doReturn listOf(notificationEntity)
+    whenever { notificationRepository.findByOfficialVisitId(999L, sort = Sort.by(Sort.Direction.DESC, "createdTime")) } doReturn listOf(notificationEntity)
 
-    val result = service.getNotificationsByOfficialVisitId(999L)
+    val result = service.getNotificationsByOfficialVisitId(999L, sort = Sort.by(Sort.Direction.DESC, "createdTime"))
 
     result.size isEqualTo 1
     with(result.first()) {
@@ -235,28 +236,28 @@ class NotificationsServiceTest {
       statusUpdatedTime isEqualTo notificationEntity.statusUpdatedTime
     }
 
-    verify(notificationRepository).findByOfficialVisitIdOrderByCreatedTimeDesc(999L)
+    verify(notificationRepository).findByOfficialVisitId(999L, sort = Sort.by(Sort.Direction.DESC, "createdTime"))
   }
 
   @Test
   fun `should return empty list when official visit has no notifications`() {
     whenever { officialVisitRepository.findById(77L) } doReturn Optional.of(createAVisitEntity(77L))
-    whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(77L) } doReturn emptyList()
+    whenever { notificationRepository.findByOfficialVisitId(77L, sort = Sort.by(Sort.Direction.DESC, "createdTime")) } doReturn emptyList()
 
-    val result = service.getNotificationsByOfficialVisitId(77L)
+    val result = service.getNotificationsByOfficialVisitId(77L, sort = Sort.by(Sort.Direction.DESC, "createdTime"))
 
     result.isEmpty() isEqualTo true
-    verify(notificationRepository).findByOfficialVisitIdOrderByCreatedTimeDesc(77L)
+    verify(notificationRepository).findByOfficialVisitId(77L, sort = Sort.by(Sort.Direction.DESC, "createdTime"))
   }
 
   @Test
   fun `should throw not found when official visit not found`() {
     val officialVisitId = 77L
     whenever { officialVisitRepository.findById(officialVisitId) } doReturn Optional.empty()
-    whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId) } doReturn emptyList()
+    whenever { notificationRepository.findByOfficialVisitId(officialVisitId, sort = Sort.by(Sort.Direction.DESC, "createdTime")) } doReturn emptyList()
 
     assertThrows<EntityNotFoundException> {
-      service.getNotificationsByOfficialVisitId(officialVisitId)
+      service.getNotificationsByOfficialVisitId(officialVisitId, sort = Sort.by(Sort.Direction.DESC, "createdTime"))
     }.message isEqualTo "Official visit with id $officialVisitId not found"
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service.notifications
 
+import jakarta.persistence.EntityNotFoundException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -215,7 +217,7 @@ class NotificationsServiceTest {
       createdTime = createdTime,
       statusUpdatedTime = statusUpdatedTime,
     )
-
+    whenever { officialVisitRepository.findById(999L) } doReturn Optional.of(createAVisitEntity(999L))
     whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(999L) } doReturn listOf(notificationEntity)
 
     val result = service.getNotificationsByOfficialVisitId(999L)
@@ -238,12 +240,24 @@ class NotificationsServiceTest {
 
   @Test
   fun `should return empty list when official visit has no notifications`() {
+    whenever { officialVisitRepository.findById(77L) } doReturn Optional.of(createAVisitEntity(77L))
     whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(77L) } doReturn emptyList()
 
     val result = service.getNotificationsByOfficialVisitId(77L)
 
     result.isEmpty() isEqualTo true
     verify(notificationRepository).findByOfficialVisitIdOrderByCreatedTimeDesc(77L)
+  }
+
+  @Test
+  fun `should throw not found when official visit not found`() {
+    val officialVisitId = 77L
+    whenever { officialVisitRepository.findById(officialVisitId) } doReturn Optional.empty()
+    whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId) } doReturn emptyList()
+
+    assertThrows<EntityNotFoundException> {
+      service.getNotificationsByOfficialVisitId(officialVisitId)
+    }.message isEqualTo "Official visit with id $officialVisitId not found"
   }
 
   object FakeEmail : Email("email@address") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toHourMinuteStyle
 import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toMediumFormatStyle
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEmailStatus
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
@@ -33,6 +34,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.EmailType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.OfficialVisitCancelledEmail
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.OfficialVisitCreatedEmail
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.emails.OfficialVisitUpdatedEmail
+import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID
 
@@ -196,6 +198,52 @@ class NotificationsServiceTest {
       "user_name" to MOORLAND_PRISON_USER.name,
       "visitor_names" to "Community Manager, Prison Manager",
     )
+  }
+
+  @Test
+  fun `should return mapped notifications for official visit id`() {
+    val createdTime = LocalDateTime.now()
+    val statusUpdatedTime = createdTime.plusMinutes(10)
+    val notificationEntity = NotificationEntity(
+      notificationId = 123L,
+      officialVisitId = 999L,
+      templateId = "template-1",
+      emailAddress = "email@address.com",
+      reason = "OFFICIAL_VISIT_CREATED",
+      govNotifyNotificationId = UUID.randomUUID(),
+      emailStatus = NotificationEmailStatus.SENT,
+      createdTime = createdTime,
+      statusUpdatedTime = statusUpdatedTime,
+    )
+
+    whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(999L) } doReturn listOf(notificationEntity)
+
+    val result = service.getNotificationsByOfficialVisitId(999L)
+
+    result.size isEqualTo 1
+    with(result.first()) {
+      notificationId isEqualTo notificationEntity.notificationId
+      officialVisitId isEqualTo notificationEntity.officialVisitId
+      templateId isEqualTo notificationEntity.templateId
+      emailAddress isEqualTo notificationEntity.emailAddress
+      reason isEqualTo notificationEntity.reason
+      govNotifyNotificationId isEqualTo notificationEntity.govNotifyNotificationId
+      emailStatus isEqualTo notificationEntity.emailStatus
+      createdTime isEqualTo notificationEntity.createdTime
+      statusUpdatedTime isEqualTo notificationEntity.statusUpdatedTime
+    }
+
+    verify(notificationRepository).findByOfficialVisitIdOrderByCreatedTimeDesc(999L)
+  }
+
+  @Test
+  fun `should return empty list when official visit has no notifications`() {
+    whenever { notificationRepository.findByOfficialVisitIdOrderByCreatedTimeDesc(77L) } doReturn emptyList()
+
+    val result = service.getNotificationsByOfficialVisitId(77L)
+
+    result.isEmpty() isEqualTo true
+    verify(notificationRepository).findByOfficialVisitIdOrderByCreatedTimeDesc(77L)
   }
 
   object FakeEmail : Email("email@address") {


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve all notifications sent for a given official visit, along with the necessary backend and test support. 