### PR TITLE
OV-504 this is just laying out the initial contract/endpoint for getting audited events by the visit identifier. There is no underlying implementation.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/AuditedEventResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/AuditedEventResponse.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.model.response
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class AuditedEventResponse(
+  @Schema(description = "The audited event identifier", example = "1")
+  val auditedEventId: Long,
+
+  @Schema(description = "The official visit identifier", example = "1")
+  val officialVisitId: Long,
+
+  @Schema(description = "A short summary of the audit event", example = "Visit updated")
+  val eventSummary: String,
+
+  @Schema(description = "The type of audit event", example = "UPDATE", allowableValues = ["CREATE", "UPDATE"])
+  val eventType: String,
+
+  @Schema(description = "The changes related to an update, otherwise empty", example = "[{\"field\":\"start_time\",\"oldValue\":\"12:00\",\"newValue\":\"17:00\"},{\"field\":\"end_time\",\"oldValue\":\"14:00\",\"newValue\":\"19:00\"}]")
+  val eventChanges: List<AuditedEventChange>,
+
+  @Schema(description = "The date and time the audited event was recorded", example = "2026-05-04 09:50")
+  val eventDateTime: LocalDateTime,
+
+  @Schema(description = "The username of the user responsible for the audited event", example = "X999X")
+  val eventUsername: String,
+
+  @Schema(description = "The full name of the user responsible for the audited event", example = "Fred Bloggs")
+  val eventUserFullName: String,
+) {
+  @Schema(
+    description =
+    """
+    A boolean indicator to determine if the audited event is considered a significant change to the official visit.
+    """,
+    example = "true",
+  )
+  val significantChange: Boolean = eventChanges.any(AuditedEventChange::significantChange)
+}
+
+data class AuditedEventChange(
+  @Schema(description = "The name of the field affected by the audited event", example = "start_time")
+  val field: String,
+
+  @Schema(description = "The old value of the field affected by the audited event", example = "12:00")
+  val oldValue: String?,
+
+  @Schema(description = "The new value of the field affected by the audited event", example = "17:00")
+  val newValue: String?,
+
+  @JsonIgnore
+  val significantChange: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/OfficialVisitController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -32,6 +33,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisi
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitUpdateSlotRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitUpdateVisitorsRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OverlappingVisitsCriteriaRequest
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.AuditedEventResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.CreateOfficialVisitResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitDetails
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitSummarySearchResponse
@@ -419,4 +421,38 @@ class OfficialVisitController(private val facade: OfficialVisitFacade) {
     @Parameter(description = "The request with the overlapping criteria to check against", required = true)
     request: OverlappingVisitsCriteriaRequest,
   ) = facade.findOverlappingScheduledVisits(prisonCode, request)
+
+  @GetMapping("/id/{officialVisitId}/audited-events")
+  @Operation(
+    summary = "Get the audited events for an official visit",
+    description = "Get the audited event details of an official visit",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returns a list of audited events",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = AuditedEventResponse::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Official visit not found",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN', 'ROLE_OFFICIAL_VISITS__R', 'ROLE_OFFICIAL_VISITS_RW')")
+  fun getOfficialVisitAuditedEvents(
+    @PathVariable @Parameter(
+      name = "officialVisitId",
+      description = "The official visit ID",
+      example = "123456",
+      required = true,
+    ) officialVisitId: Long,
+  ): List<AuditedEventResponse> = emptyList()
 }


### PR DESCRIPTION
Groundwork PR to help set up the initial contract for getting audited events by the official visit identifier.  No results are returned, just an empty list.

The response would look like something below:

```
[
  {
    "auditedEventId": 1,
    "officialVisitId": 1,
    "eventSummary": "Visit updated",
    "eventType": "UPDATE",
    "eventChanges": [
      {
        "field": "start_time",
        "oldValue": "12:00",
        "newValue": "17:00"
      },
      {
        "field": "end_time",
        "oldValue": "14:00",
        "newValue": "19:00"
      }
    ],
    "eventDateTime": "2026-05-04 09:50",
    "eventUsername": "X999X",
    "eventUserFullName": "Fred Bloggs",
    "significantChange": true
  }
]
```