### PR TITLE
OV-738: Check and correct access roles

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/admin/PrisonTimeSlotController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/admin/PrisonTimeSlotController.kt
@@ -58,7 +58,7 @@ class PrisonTimeSlotController(val facade: PrisonTimeSlotFacade) {
       ),
     ],
   )
-  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_ADMIN')")
+  @PreAuthorize("hasAnyRole('ROLE_OFFICIAL_VISITS_ADMIN')")
   fun getAllTimeSlotsAndVisitSlots(
     @Parameter(description = "The prison code", required = true)
     @PathVariable prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/sync/OfficialVisitSyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/sync/OfficialVisitSyncController.kt
@@ -52,7 +52,7 @@ class OfficialVisitSyncController(private val syncFacade: SyncFacade) {
       ),
     ],
   )
-  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION', 'OFFICIAL_VISITS_ADMIN')")
+  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION')")
   fun getOfficialVisitById(
     @PathVariable(required = true) officialVisitId: Long,
   ): SyncOfficialVisit = syncFacade.getOfficialVisitById(officialVisitId)
@@ -155,6 +155,7 @@ class OfficialVisitSyncController(private val syncFacade: SyncFacade) {
   @Operation(
     summary = "Delete an official visit by ID",
     description = """
+      Requires role: OFFICIAL_VISITS_MIGRATION.
       Delete an official visit including all related information. 
       This endpoint is idempotent, so if the visit is not present it will silently succeed.
       """,
@@ -167,7 +168,7 @@ class OfficialVisitSyncController(private val syncFacade: SyncFacade) {
       ),
     ],
   )
-  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION', 'OFFICIAL_VISITS_ADMIN')")
+  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION')")
   @ResponseStatus(value = HttpStatus.NO_CONTENT)
   fun syncDeleteOfficialVisit(
     @Parameter(description = "The official visit ID to remove", required = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/sync/ReconciliationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/sync/ReconciliationController.kt
@@ -35,7 +35,7 @@ class ReconciliationController(private val reconciliationService: Reconciliation
 
   @Operation(summary = "Return a paged list of all official visit IDs")
   @GetMapping(value = ["/official-visits/identifiers"], produces = [MediaType.APPLICATION_JSON_VALUE])
-  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION', 'OFFICIAL_VISITS_ADMIN')")
+  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION')")
   @PageableAsQueryParam
   @ApiResponses(
     value = [
@@ -69,7 +69,7 @@ class ReconciliationController(private val reconciliationService: Reconciliation
     ],
   )
   @GetMapping(value = ["/official-visit/id/{officialVisitId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION', 'OFFICIAL_VISITS_ADMIN')")
+  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION')")
   fun getOfficialVisitById(
     @PathVariable(required = true) officialVisitId: Long,
   ): SyncOfficialVisit = reconciliationService.getOfficialVisitById(officialVisitId)
@@ -90,8 +90,8 @@ class ReconciliationController(private val reconciliationService: Reconciliation
     ],
   )
   @GetMapping(value = ["/prisoner/{prisonerNumber}"], produces = [MediaType.APPLICATION_JSON_VALUE])
-  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION', 'OFFICIAL_VISITS_ADMIN')")
-  fun getAllOfficialVisitForPrisoner(
+  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION')")
+  fun getAllOfficialVisitsForPrisoner(
     @PathVariable(required = true) @Parameter(description = "Prisoner number", required = true)
     prisonerNumber: String,
     @Parameter(description = "Current term only, true of false. Defaults to true.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/sync/RepairPrisonerVisitsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/resource/sync/RepairPrisonerVisitsController.kt
@@ -50,7 +50,7 @@ class RepairPrisonerVisitsController(val repairPrisonerVisitsService: RepairPris
       ),
     ],
   )
-  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION', 'OFFICIAL_VISITS_ADMIN')")
+  @PreAuthorize("hasAnyRole('OFFICIAL_VISITS_MIGRATION')")
   fun repairPrisonerVisits(
     @PathVariable(required = true) prisonerNumber: String,
     @Valid @RequestBody request: RepairPrisonerVisitsRequest,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/admin/VisitSlotIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/admin/VisitSlotIntegrationTest.kt
@@ -95,7 +95,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
       .headers(
         setAuthorisation(
           username = MOORLAND_PRISON_USER.username,
-          roles = listOf("ROLE_OFFICIAL_VISITS_STAFF"),
+          roles = listOf("ROLE_WRONG_ONE"),
         ),
       )
       .exchange()
@@ -109,7 +109,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
       .headers(
         setAuthorisation(
           username = MOORLAND_PRISON_USER.username,
-          roles = listOf("ROLE_OFFICIAL_VISITS_STAFF"),
+          roles = listOf("ROLE_WRONG_ONE"),
         ),
       )
       .bodyValue(createVisitSlotRequest())
@@ -124,7 +124,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
       .headers(
         setAuthorisation(
           username = MOORLAND_PRISON_USER.username,
-          roles = listOf("ROLE_OFFICIAL_VISITS_STAFF"),
+          roles = listOf("ROLE_WRONG_ONE"),
         ),
       )
       .bodyValue(updateVisitSlotRequest())
@@ -138,7 +138,7 @@ class VisitSlotIntegrationTest : IntegrationTestBase() {
       .headers(
         setAuthorisation(
           username = MOORLAND_PRISON_USER.username,
-          roles = listOf("ROLE_OFFICIAL_VISITS_STAFF"),
+          roles = listOf("ROLE_WRONG_ONE"),
         ),
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/RepairPrisonerVisitsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/RepairPrisonerVisitsIntegrationTest.kt
@@ -148,7 +148,7 @@ class RepairPrisonerVisitsIntegrationTest : IntegrationTestBase() {
     .uri("/repair/prisoner-visits/$prisonerNumber", prisonerNumber)
     .bodyValue(request)
     .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_ADMIN")))
+    .headers(setAuthorisation(username = prisonUser.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
@@ -111,7 +111,7 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
     val syncOfficialVisit = webTestClient.get()
       .uri("/sync/official-visit/id/{officialVisitId}", savedOfficialVisitId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
       .exchange()
       .expectStatus()
       .isOk
@@ -127,7 +127,7 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
     webTestClient.get()
       .uri("/sync/official-visit/id/{officialVisitId}", 999)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
       .exchange()
       .expectStatus()
       .is4xxClientError
@@ -542,7 +542,7 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
     .delete()
     .uri("/sync/official-visit/id/{officialVisitId}", officialVisitId)
     .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
     .exchange()
     .expectStatus()
     .is2xxSuccessful

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
@@ -452,7 +452,7 @@ class SyncOfficialVisitorsIntegrationTest : IntegrationTestBase() {
   private fun WebTestClient.syncGetVisit(officialVisitId: Long) = this.get()
     .uri("/sync/official-visit/id/{officialVisitId}", officialVisitId)
     .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
     .exchange()
     .expectStatus()
     .isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncTimeSlotIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncTimeSlotIntegrationTest.kt
@@ -67,7 +67,7 @@ class SyncTimeSlotIntegrationTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = ["ROLE_PRISON", "ROLE_OFFICIAL_VISITS__R", "ROLE_OFFICIAL_VISITS__RW"])
+  @ValueSource(strings = ["ROLE_OFFICIAL_VISITS__R", "ROLE_OFFICIAL_VISITS__RW"])
   fun `should return forbidden without an authorised role`(role: String) {
     webTestClient.get()
       .uri("/sync/time-slot/{prisonTimeSlotId}", savedPrisonTimeSlotId)
@@ -103,7 +103,7 @@ class SyncTimeSlotIntegrationTest : IntegrationTestBase() {
     val syncTimeSlot = webTestClient.get()
       .uri("/sync/time-slot/{prisonTimeSlotId}", savedPrisonTimeSlotId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
       .exchange()
       .expectStatus()
       .isOk
@@ -141,7 +141,7 @@ class SyncTimeSlotIntegrationTest : IntegrationTestBase() {
       .uri("/sync/time-slot/{prisonTimeSlotId}", savedPrisonTimeSlotId)
       .accept(MediaType.APPLICATION_JSON)
       .contentType(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
       .bodyValue(updateRequest)
       .exchange()
       .expectStatus()
@@ -175,7 +175,7 @@ class SyncTimeSlotIntegrationTest : IntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/time-slot/{prisonTimeSlotId}", timeSlot.prisonTimeSlotId)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
       .exchange()
       .expectStatus()
       .is2xxSuccessful
@@ -196,7 +196,7 @@ class SyncTimeSlotIntegrationTest : IntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/time-slot/{prisonTimeSlotId}", 99)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
       .exchange()
       .expectStatus().isEqualTo(HttpStatus.NO_CONTENT)
 
@@ -208,7 +208,7 @@ class SyncTimeSlotIntegrationTest : IntegrationTestBase() {
     webTestClient.delete()
       .uri("/sync/time-slot/{prisonTimeSlotId}", 1L)
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+      .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
       .exchange()
       .expectStatus().isEqualTo(HttpStatus.CONFLICT)
       .expectBody().jsonPath("$.userMessage").isEqualTo("The prison time slot has one or more visit slots associated with it and cannot be deleted.")
@@ -251,7 +251,7 @@ class SyncTimeSlotIntegrationTest : IntegrationTestBase() {
     .uri("/sync/time-slot")
     .accept(MediaType.APPLICATION_JSON)
     .contentType(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("OFFICIAL_VISITS_MIGRATION")))
+    .headers(setAuthorisation(username = MOORLAND_PRISON_USER.username, roles = listOf("ROLE_OFFICIAL_VISITS_MIGRATION")))
     .bodyValue(createTimeSlotRequest())
     .exchange()
     .expectStatus()


### PR DESCRIPTION
This PR streamlines the role accesses for endpoints.

The main area was in the sync, migrate and reconcile endpoints. These should only ever be called by Syscon services which have the ROLE_OFFICIAL_VISITS_MIGRATION role. 

However, some of these were allowing ROLE_OFFICIAL_VISITS_ADMIN,  a role given to the UI client, which should never directly call a /sync, /migrate or /reconcile endpoint.

All tests were fine, this is just for safety and a clean division between endpoints for Syscon and those intended for our own UI client.
