### PR TITLE
OV-724 : Add handling for prisoner booking deleted events and related…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
@@ -107,8 +107,8 @@ enum class DomainEventType(val eventType: String, val description: String = "") 
   abstract fun toInboundEvent(mapper: ObjectMapper, message: String): DomainEvent<*>
 }
 
-enum class Identifier { PERSON }
+enum class Identifier { NOMS }
 data class PersonIdentifier(val type: Identifier, val value: String)
 data class PersonReference(val identifiers: List<PersonIdentifier>) {
-  fun prisonerNumber(): String? = identifiers.firstOrNull { it.type == Identifier.PERSON }?.value
+  fun prisonerNumber(): String? = identifiers.firstOrNull { it.type == Identifier.NOMS }?.value
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/DomainEvents.kt
@@ -4,18 +4,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import uk.gov.justice.digital.hmpps.officialvisitsapi.common.toOffsetString
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.outbound.Identifier
 import java.time.LocalDateTime
 
 abstract class DomainEvent<T : AdditionalInformation>(
   eventType: DomainEventType,
   val additionalInformation: T,
+  val personReference: PersonReference = PersonReference(emptyList()),
 ) {
   val eventType = eventType.eventType
   val description = eventType.description
   val version: String = "1"
   val occurredAt: String = LocalDateTime.now().toOffsetString()
-
   fun toEventType() = DomainEventType.valueOf(eventType)
 
   override fun toString() = this::class.simpleName + " - (eventType = $eventType, , occurredAt = $occurredAt, additionalInformation = $additionalInformation)"
@@ -75,11 +74,17 @@ class PrisonerBookingMovedEvent(additionalInformation: BookingMovedInformation) 
   fun bookingStartDateTime() = additionalInformation.bookingStartDateTime
 }
 
+class PrisonerBookingDeletedEvent(additionalInformation: BookingDeletedInformation, personReference: PersonReference = PersonReference(emptyList())) : DomainEvent<BookingDeletedInformation>(DomainEventType.PRISONER_BOOKING_DELETED, additionalInformation, personReference) {
+  @JsonIgnore
+  fun bookingId() = additionalInformation.bookingId
+
+  @JsonIgnore
+  fun prisonerNumber() = personReference.prisonerNumber()
+}
+
 data class BookingMovedInformation(val movedFromNomsNumber: String, val movedToNomsNumber: String, val bookingId: String, val bookingStartDateTime: LocalDateTime) : AdditionalInformation
 
-data class PersonReference(val identifiers: List<Identifier>)
-
-data class Identifier(val type: String, val value: String)
+data class BookingDeletedInformation(val bookingId: String) : AdditionalInformation
 
 enum class DomainEventType(val eventType: String, val description: String = "") {
   PRISONER_RECEIVED("prisoner-offender-search.prisoner.received") {
@@ -94,7 +99,16 @@ enum class DomainEventType(val eventType: String, val description: String = "") 
   PRISONER_BOOKING_MOVED("prison-offender-events.prisoner.booking.moved") {
     override fun toInboundEvent(mapper: ObjectMapper, message: String) = mapper.readValue<PrisonerBookingMovedEvent>(message)
   },
+  PRISONER_BOOKING_DELETED("prison-offender-events.prisoner.booking.deleted") {
+    override fun toInboundEvent(mapper: ObjectMapper, message: String) = mapper.readValue<PrisonerBookingDeletedEvent>(message)
+  },
   ;
 
   abstract fun toInboundEvent(mapper: ObjectMapper, message: String): DomainEvent<*>
+}
+
+enum class Identifier { PERSON }
+data class PersonIdentifier(val type: Identifier, val value: String)
+data class PersonReference(val identifiers: List<PersonIdentifier>) {
+  fun prisonerNumber(): String? = identifiers.firstOrNull { it.type == Identifier.PERSON }?.value
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerBookingDeletedEventHandler
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerBookingMovedEventHandler
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerReceivedEventHandler
@@ -14,6 +15,7 @@ class InboundEventsService(
   private val prisonerMergedEventHandler: PrisonerMergedEventHandler,
   private val prisonerReceivedEventHandler: PrisonerReceivedEventHandler,
   private val prisonerBookingMovedEventHandler: PrisonerBookingMovedEventHandler,
+  private val prisonerBookingDeletedEventHandler: PrisonerBookingDeletedEventHandler,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -25,6 +27,7 @@ class InboundEventsService(
       is PrisonerReleasedEvent -> prisonerReleasedEventHandler.handle(event)
       is PrisonerReceivedEvent -> prisonerReceivedEventHandler.handle(event)
       is PrisonerBookingMovedEvent -> prisonerBookingMovedEventHandler.handle(event)
+      is PrisonerBookingDeletedEvent -> prisonerBookingDeletedEventHandler.handle(event)
       else -> log.warn("Unsupported domain event ${event.javaClass.name}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingDeletedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingDeletedEventHandler.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.PrisonerBookingDeletedEvent
+
+@Component
+class PrisonerBookingDeletedEventHandler(
+  private val officialVisitRepository: OfficialVisitRepository,
+  private val auditingService: AuditingService,
+) : DomainEventHandler<PrisonerBookingDeletedEvent> {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional
+  override fun handle(event: PrisonerBookingDeletedEvent) {
+    val bookingId = event.bookingId().toLong()
+    val prisonerNumber = event.prisonerNumber()
+    log.warn("Received booking deleted event for booking [$bookingId] with prisoner number [$prisonerNumber]")
+    return
+  }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -43,4 +43,7 @@
   <logger name="org.hibernate.orm.connections.pooling" additivity="false" level="WARN">
     <appender-ref ref="consoleAppender"/>
   </logger>
+
+  <logger name="uk.gov.justice.hmpps.kotlin.clienttracking" level="OFF" additivity="false"/>
+
 </configuration>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsListenerTest.kt
@@ -76,6 +76,26 @@ class InboundEventsListenerTest {
     )
   }
 
+  @Test
+  fun `should delegate prisoner booking deleted domain event to service`() {
+    val event = PrisonerBookingDeletedEvent(
+      BookingDeletedInformation("123"),
+      PersonReference(listOf(PersonIdentifier(Identifier.PERSON, "A1111AA"))),
+    )
+    val message = message(event)
+    val rawMessage = mapper.writeValueAsString(message)
+
+    eventListener.onMessage(rawMessage)
+
+    verify(inboundEventsService).process(
+      mockitoCheck {
+        it isInstanceOf PrisonerBookingDeletedEvent::class.java
+        (it as PrisonerBookingDeletedEvent).additionalInformation.bookingId isEqualTo "123"
+        it.personReference.prisonerNumber() isEqualTo "A1111AA"
+      },
+    )
+  }
+
   private fun message(event: DomainEvent<*>) = Message(
     "Notification",
     mapper.writeValueAsString(event),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsListenerTest.kt
@@ -80,7 +80,7 @@ class InboundEventsListenerTest {
   fun `should delegate prisoner booking deleted domain event to service`() {
     val event = PrisonerBookingDeletedEvent(
       BookingDeletedInformation("123"),
-      PersonReference(listOf(PersonIdentifier(Identifier.PERSON, "A1111AA"))),
+      PersonReference(listOf(PersonIdentifier(Identifier.NOMS, "A1111AA"))),
     )
     val message = message(event)
     val rawMessage = mapper.writeValueAsString(message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/InboundEventsServiceTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.BIRMINGHAM
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerBookingDeletedEventHandler
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerBookingMovedEventHandler
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerMergedEventHandler
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerReceivedEventHandler
@@ -14,12 +15,14 @@ class InboundEventsServiceTest {
   private val prisonerMergedEventHandler: PrisonerMergedEventHandler = mock()
   private val prisonerReceivedEventHandler: PrisonerReceivedEventHandler = mock()
   private val prisonerMovedEventHandler: PrisonerBookingMovedEventHandler = mock()
+  private val prisonerDeletedEventHandler: PrisonerBookingDeletedEventHandler = mock()
 
   private val service = InboundEventsService(
     prisonerReleasedEventHandler,
     prisonerMergedEventHandler,
     prisonerReceivedEventHandler,
     prisonerMovedEventHandler,
+    prisonerDeletedEventHandler,
   )
 
   @Test
@@ -52,5 +55,12 @@ class InboundEventsServiceTest {
     val event = mock<PrisonerBookingMovedEvent>()
     service.process(event)
     verify(prisonerMovedEventHandler).handle(event)
+  }
+
+  @Test
+  fun `should call prisoner booking deleted event handler when prisoner booking deleted event`() {
+    val event = mock<PrisonerBookingDeletedEvent>()
+    service.process(event)
+    verify(prisonerDeletedEventHandler).handle(event)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingDeletedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingDeletedEventHandlerTest.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerBookingDeletedEventHandler
+import java.time.LocalDateTime
+
+class PrisonerBookingDeletedEventHandlerTest {
+  private val officialVisitRepository: OfficialVisitRepository = mock()
+  private val auditingService: AuditingService = mock()
+
+  private val handler = PrisonerBookingDeletedEventHandler(officialVisitRepository, auditingService)
+
+  @Test
+  fun `should update visits and set current term for a booking deleted event`() {
+    val bookingStartDateTime = LocalDateTime.now()
+
+    val bookingDeletedEvent = PrisonerBookingDeletedEvent(
+      BookingDeletedInformation("1"),
+      PersonReference(listOf(PersonIdentifier(Identifier.PERSON, "ABC222"))),
+    )
+
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdAndCreatedTimeGreaterThanEqual("ABC222", 1L, bookingStartDateTime)).thenReturn(
+      listOf(createAVisitEntity(1L), createAVisitEntity(2L)),
+    )
+
+    handler.handle(bookingDeletedEvent)
+  }
+
+  @Test
+  fun `should not try to update visits when the count for prisoner number and booking ID is zero`() {
+    val bookingStartDateTime = LocalDateTime.now()
+
+    val bookingDeletedEvent = PrisonerBookingDeletedEvent(
+      BookingDeletedInformation("1"),
+      PersonReference(listOf(PersonIdentifier(Identifier.PERSON, "ABC222"))),
+    )
+
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdAndCreatedTimeGreaterThanEqual("ABC222", 1L, bookingStartDateTime)).thenReturn(emptyList())
+
+    handler.handle(bookingDeletedEvent)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingDeletedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingDeletedEventHandlerTest.kt
@@ -21,7 +21,7 @@ class PrisonerBookingDeletedEventHandlerTest {
 
     val bookingDeletedEvent = PrisonerBookingDeletedEvent(
       BookingDeletedInformation("1"),
-      PersonReference(listOf(PersonIdentifier(Identifier.PERSON, "ABC222"))),
+      PersonReference(listOf(PersonIdentifier(Identifier.NOMS, "ABC222"))),
     )
 
     whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdAndCreatedTimeGreaterThanEqual("ABC222", 1L, bookingStartDateTime)).thenReturn(
@@ -37,7 +37,7 @@ class PrisonerBookingDeletedEventHandlerTest {
 
     val bookingDeletedEvent = PrisonerBookingDeletedEvent(
       BookingDeletedInformation("1"),
-      PersonReference(listOf(PersonIdentifier(Identifier.PERSON, "ABC222"))),
+      PersonReference(listOf(PersonIdentifier(Identifier.NOMS, "ABC222"))),
     )
 
     whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdAndCreatedTimeGreaterThanEqual("ABC222", 1L, bookingStartDateTime)).thenReturn(emptyList())


### PR DESCRIPTION
This pull request introduces support for handling "prisoner booking deleted" domain events in the official visits API. It adds a new event type, handler, and related tests to ensure the event is processed correctly, and updates the domain model to accommodate the new event structure.

This is the initial setup for receiving part of the domain event. The processing details will be done as part of the next PRs.

- Expected payload :
**
<img width="562" height="488" alt="image" src="https://github.com/user-attachments/assets/b291d545-1228-405c-963c-100c735f01b9" />
**
