### PR TITLE
OV-724: domain event refactor to use a common component for current term markers.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/CurrentTermComponent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/CurrentTermComponent.kt
@@ -38,22 +38,20 @@ class CurrentTermComponent(
 
     // Find visits that match the prisoner number and current bookingId, if currentTerm = false set it to true
     officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber, prisoner.bookingId!!.toLong())
+      .filterNot { it.currentTerm }
       .forEach { visit ->
-        if (!visit.currentTerm) {
-          officialVisitRepository.saveAndFlush(visit.apply { currentTerm = true })
-          auditCurrentTermChange(visit, true)
-          currentTermCounter++
-        }
+        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = true })
+        auditCurrentTermChange(visit, true)
+        currentTermCounter++
       }
 
     // Find visits that match the prisoner number but NOT the current bookingId, if currentTerm = true set it to false
     officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber, prisoner.bookingId.toLong())
+      .filter { it.currentTerm }
       .forEach { visit ->
-        if (visit.currentTerm) {
-          officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
-          auditCurrentTermChange(visit, false)
-          previousTermCounter++
-        }
+        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
+        auditCurrentTermChange(visit, false)
+        previousTermCounter++
       }
 
     log.info("$source : Prisoner [$prisonerNumber] [$currentTermCounter] set to currentTerm = true, [$previousTermCounter] set to currentTerm = false")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/CurrentTermComponent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/CurrentTermComponent.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers
+
+import jakarta.persistence.EntityNotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCurrentTermEvent
+
+/**
+ * This is a shared component that is used by most of the domain event handlers
+ * to find and reset the currentTerm markers on visits for a prisoner
+ * based on whether the bookingId on the visit is their active booking.
+ */
+
+@Component
+class CurrentTermComponent(
+  private val officialVisitRepository: OfficialVisitRepository,
+  private val prisonerSearchClient: PrisonerSearchClient,
+  private val auditingService: AuditingService,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional
+  fun processCurrentTermMarkers(prisonerNumber: String, source: String) {
+    var currentTermCounter = 0
+    var previousTermCounter = 0
+
+    // Get the current bookingId for this prisoner
+    val prisoner = prisonerSearchClient.getPrisoner(prisonerNumber)
+      ?: throw EntityNotFoundException("Prisoner not found $prisonerNumber")
+
+    // Find visits that match the prisoner number and current bookingId, if currentTerm = false set it to true
+    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber, prisoner.bookingId!!.toLong())
+      .forEach { visit ->
+        if (!visit.currentTerm) {
+          officialVisitRepository.saveAndFlush(visit.apply { currentTerm = true })
+          auditCurrentTermChange(visit, true)
+          currentTermCounter++
+        }
+      }
+
+    // Find visits that match the prisoner number but NOT the current bookingId, if currentTerm = true set it to false
+    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber, prisoner.bookingId.toLong())
+      .forEach { visit ->
+        if (visit.currentTerm) {
+          officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
+          auditCurrentTermChange(visit, false)
+          previousTermCounter++
+        }
+      }
+
+    log.info("$source : Prisoner [$prisonerNumber] [$currentTermCounter] set to currentTerm = true, [$previousTermCounter] set to currentTerm = false")
+  }
+
+  private fun auditCurrentTermChange(visit: OfficialVisitEntity, currentTermMarker: Boolean) = auditingService.recordAuditEvent(
+    auditVisitCurrentTermEvent {
+      officialVisitId(visit.officialVisitId)
+      summaryText("Current term marker updated to $currentTermMarker")
+      eventSource("NOMIS")
+      user(UserService.getServiceAsUser())
+      prisonCode(visit.prisonCode)
+      prisonerNumber(visit.prisonerNumber)
+    },
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingDeletedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingDeletedEventHandler.kt
@@ -4,13 +4,16 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitChangeEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.PrisonerBookingDeletedEvent
 
 @Component
 class PrisonerBookingDeletedEventHandler(
   private val officialVisitRepository: OfficialVisitRepository,
   private val auditingService: AuditingService,
+  private val currentTermComponent: CurrentTermComponent,
 ) : DomainEventHandler<PrisonerBookingDeletedEvent> {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -19,8 +22,36 @@ class PrisonerBookingDeletedEventHandler(
   @Transactional
   override fun handle(event: PrisonerBookingDeletedEvent) {
     val bookingId = event.bookingId().toLong()
-    val prisonerNumber = event.prisonerNumber()
-    log.warn("Received booking deleted event for booking [$bookingId] with prisoner number [$prisonerNumber]")
-    return
+    val prisonerNumber = event.prisonerNumber()!!
+
+    log.info("Received booking deleted event for bookingId [$bookingId] prisoner number [$prisonerNumber]")
+
+    // Find all visits for this prisoner number and bookingId (they are affected by this event)
+    val affectedVisits = officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(
+      prisonerNumber,
+      bookingId,
+    )
+
+    // Record an audit event for affected visits
+    affectedVisits.takeIf { it.isNotEmpty() }?.let {
+      affectedVisits.forEach { visit ->
+        auditingService.recordAuditEvent(
+          auditVisitChangeEvent {
+            officialVisitId(visit.officialVisitId)
+            summaryText("Official visit updated due to its booking being deleted")
+            eventSource("NOMIS")
+            user(UserService.getClientAsUser("NOMIS"))
+            prisonCode(visit.prisonCode)
+            prisonerNumber(prisonerNumber)
+            changes {
+              change("Booking deleted", event.bookingId(), "")
+            }
+          },
+        )
+      }
+    }
+
+    // Adjust current term markers on the visits for this prisoner
+    currentTermComponent.processCurrentTermMarkers(prisonerNumber, "BOOKING DELETED EVENT")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingDeletedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingDeletedEventHandler.kt
@@ -33,22 +33,20 @@ class PrisonerBookingDeletedEventHandler(
     )
 
     // Record an audit event for affected visits
-    affectedVisits.takeIf { it.isNotEmpty() }?.let {
-      affectedVisits.forEach { visit ->
-        auditingService.recordAuditEvent(
-          auditVisitChangeEvent {
-            officialVisitId(visit.officialVisitId)
-            summaryText("Official visit updated due to its booking being deleted")
-            eventSource("NOMIS")
-            user(UserService.getClientAsUser("NOMIS"))
-            prisonCode(visit.prisonCode)
-            prisonerNumber(prisonerNumber)
-            changes {
-              change("Booking deleted", event.bookingId(), "")
-            }
-          },
-        )
-      }
+    affectedVisits.forEach { visit ->
+      auditingService.recordAuditEvent(
+        auditVisitChangeEvent {
+          officialVisitId(visit.officialVisitId)
+          summaryText("Official visit updated due to its booking being deleted")
+          eventSource("NOMIS")
+          user(UserService.getClientAsUser("NOMIS"))
+          prisonCode(visit.prisonCode)
+          prisonerNumber(prisonerNumber)
+          changes {
+            change("Booking deleted", event.bookingId(), "")
+          }
+        },
+      )
     }
 
     // Adjust current term markers on the visits for this prisoner

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingMovedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingMovedEventHandler.kt
@@ -15,6 +15,7 @@ class PrisonerBookingMovedEventHandler(
   private val officialVisitRepository: OfficialVisitRepository,
   private val prisonerVisitedRepository: PrisonerVisitedRepository,
   private val auditingService: AuditingService,
+  private val currentTermComponent: CurrentTermComponent,
 ) : DomainEventHandler<PrisonerBookingMovedEvent> {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -28,17 +29,22 @@ class PrisonerBookingMovedEventHandler(
     val startDateTime = event.bookingStartDateTime()
 
     log.info("Handling booking move from [$movedFromNomsNumber] to [$movedToNomsNumber] for booking [$bookingId]")
+
+    // Find all visits for the prisoner and bookingId after the start date/time (these will move to the new prisoner number)
     val affectedVisits = officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdAndCreatedTimeGreaterThanEqual(
       movedFromNomsNumber,
       bookingId,
       startDateTime,
     )
 
-    // update prisoner booking if exists
     affectedVisits.takeIf { it.isNotEmpty() }?.let {
+      // Update the prisoner number on affected visits
       officialVisitRepository.bookingMove(movedFromNomsNumber, movedToNomsNumber, bookingId, startDateTime)
+
+      // Update the prisoner number on affected prisoner visited rows
       prisonerVisitedRepository.replacePrisonerNumberForBooking(movedFromNomsNumber, movedToNomsNumber, bookingId, startDateTime)
 
+      // Record an audit event for affected visits to record the change of prisoner number
       affectedVisits.forEach { visit ->
         auditingService.recordAuditEvent(
           auditVisitChangeEvent {
@@ -55,5 +61,9 @@ class PrisonerBookingMovedEventHandler(
         )
       }
     }
+
+    // Check and reset current term markers for both prisoner numbers, which may or may not be affected
+    currentTermComponent.processCurrentTermMarkers(movedFromNomsNumber, "BOOKING MOVED EVENT")
+    currentTermComponent.processCurrentTermMarkers(movedToNomsNumber, "BOOKING MOVED EVENT")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
@@ -3,13 +3,11 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.ha
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitChangeEvent
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCurrentTermEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.PrisonerMergedEvent
 
 @Component
@@ -17,6 +15,7 @@ class PrisonerMergedEventHandler(
   private val officialVisitRepository: OfficialVisitRepository,
   private val prisonerVisitedRepository: PrisonerVisitedRepository,
   private val auditingService: AuditingService,
+  private val currentTermComponent: CurrentTermComponent,
 ) : DomainEventHandler<PrisonerMergedEvent> {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -33,6 +32,7 @@ class PrisonerMergedEventHandler(
     val affectedVisits = officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)
 
     affectedVisits.takeIf { it.isNotEmpty() }?.let {
+      // This update is across all visits if any are present
       prisonerVisitedRepository.replacePrisonerNumber(removedPrisonerNumber, newPrisonerNumber)
 
       affectedVisits.forEach { visit ->
@@ -54,34 +54,7 @@ class PrisonerMergedEventHandler(
       }
     }
 
-    // Check and correct the current term markers for this prisoner's bookings - needs to be outside the empty check
-    processCurrentTermMarkers(newPrisonerNumber, bookingId.toLong())
+    // Check and update the current term markers on visits for the new prisoner only (the old prisoner number is removed)
+    currentTermComponent.processCurrentTermMarkers(newPrisonerNumber, "PRISONER MERGED EVENT")
   }
-
-  private fun processCurrentTermMarkers(prisonerNumber: String, bookingId: Long) {
-    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber, bookingId).forEach { visit ->
-      if (!visit.currentTerm) {
-        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = true })
-        auditCurrentTermChange(visit)
-      }
-    }
-
-    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber, bookingId).forEach { visit ->
-      if (visit.currentTerm) {
-        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
-        auditCurrentTermChange(visit)
-      }
-    }
-  }
-
-  private fun auditCurrentTermChange(visit: OfficialVisitEntity) = auditingService.recordAuditEvent(
-    auditVisitCurrentTermEvent {
-      officialVisitId(visit.officialVisitId)
-      summaryText("The visit current term marker has been updated by a merge")
-      eventSource("NOMIS")
-      user(UserService.getServiceAsUser())
-      prisonCode(visit.prisonCode)
-      prisonerNumber(visit.prisonerNumber)
-    },
-  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerReceivedEventHandler.kt
@@ -1,23 +1,13 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers
 
-import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
-import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
-import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.UserService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.auditVisitCurrentTermEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.PrisonerReceivedEvent
-import kotlin.String
 
 @Component
 class PrisonerReceivedEventHandler(
-  private val officialVisitRepository: OfficialVisitRepository,
-  private val auditingService: AuditingService,
-  private val prisonerSearchClient: PrisonerSearchClient,
+  private val currentTermComponent: CurrentTermComponent,
 ) : DomainEventHandler<PrisonerReceivedEvent> {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -29,56 +19,11 @@ class PrisonerReceivedEventHandler(
     val prisonCode = event.prisonCode()
     val reason = event.reason()
 
-    // Get new prisoner details to obtain the most recent bookingId - the one notified by this event
-    val prisoner = prisonerSearchClient.getPrisoner(prisonerNumber)
-      ?: throw EntityNotFoundException("Prisoner not found $prisonerNumber")
-
     if (event.indicatesANewBooking()) {
-      log.info("PRISONER RECEIVED EVENT: Processing event for [$prisonCode] [$prisonerNumber] [${prisoner.bookingId}, reason [$reason] as it indicates a new booking")
-      processNewBooking(prisonerNumber, prisoner.bookingId!!.toLong())
+      log.info("PRISONER RECEIVED EVENT: Processing event for [$prisonCode] [$prisonerNumber] [reason [$reason] indicates a new booking")
+      currentTermComponent.processCurrentTermMarkers(prisonerNumber, "PRISONER RECEIVED EVENT")
     } else {
-      log.info("PRISONER RECEIVED EVENT: Ignoring event for [$prisonCode] [$prisonerNumber] [${prisoner.bookingId}], reason [${event.reason()}] as this does not indicate a new booking")
+      log.info("PRISONER RECEIVED EVENT: Ignoring event for [$prisonCode] [$prisonerNumber] [reason [${event.reason()}] does not indicate a new booking")
     }
   }
-
-  /**
-   * This method:
-   *  - finds visits for the prisoner where the bookingId == the new booking, and sets currentTerm = true if it is false.
-   *  - finds visits for the prisoner where the bookingId != the new booking, and sets currentTerm = false if it is true.
-   *
-   * No sync events are required for this operation as these changes have already been applied in NOMIS.
-   */
-  private fun processNewBooking(prisonerNumber: String, bookingId: Long) {
-    var currentTermCounter = 0
-    var previousTermCounter = 0
-
-    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber, bookingId).forEach { visit ->
-      if (!visit.currentTerm) {
-        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = true })
-        auditCurrentTermChange(visit)
-        currentTermCounter++
-      }
-    }
-
-    officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber, bookingId).forEach { visit ->
-      if (visit.currentTerm) {
-        officialVisitRepository.saveAndFlush(visit.apply { currentTerm = false })
-        auditCurrentTermChange(visit)
-        previousTermCounter++
-      }
-    }
-
-    log.info("PRISONER RECEIVED EVENT: [$currentTermCounter] visits set to currentTerm = true, [$previousTermCounter] set to currentTerm = false")
-  }
-
-  private fun auditCurrentTermChange(visit: OfficialVisitEntity) = auditingService.recordAuditEvent(
-    auditVisitCurrentTermEvent {
-      officialVisitId(visit.officialVisitId)
-      summaryText("The visit current term marker has been updated due to a new booking")
-      eventSource("NOMIS")
-      user(UserService.getServiceAsUser())
-      prisonCode(visit.prisonCode)
-      prisonerNumber(visit.prisonerNumber)
-    },
-  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/CurrentTermComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/CurrentTermComponentTest.kt
@@ -1,0 +1,291 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE_PRISONER
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
+import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
+import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditEventDto
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.CurrentTermComponent
+
+/**
+ * This test checks that the logic for amending the currentTerm marker on visits
+ * is correct based on whether the visit.bookingId is the prisoner's current
+ * booking or not.
+ *
+ * This component is used in most of the domain event handlers to recheck and reset
+ * the current term marker after receiving an event which could alter it.
+ */
+
+class CurrentTermComponentTest {
+  private val officialVisitRepository: OfficialVisitRepository = mock()
+  private val auditingService: AuditingService = mock()
+  private val prisonerSearchClient: PrisonerSearchClient = mock()
+
+  val currentTermComponent = CurrentTermComponent(officialVisitRepository, prisonerSearchClient, auditingService)
+
+  @BeforeEach
+  fun setup() {
+    whenever(prisonerSearchClient.getPrisoner(PENTONVILLE_PRISONER.number))
+      .thenReturn(
+        prisonerSearchPrisoner(
+          prisonerNumber = PENTONVILLE_PRISONER.number, // this is 123456
+          prisonCode = PENTONVILLE_PRISONER.prison, // this is PVI
+          bookingId = PENTONVILLE_PRISONER.bookingId, // this is 1L
+        ),
+      )
+  }
+
+  @Test
+  fun `should update current term marker for visit ID 1 to true, visit ID 3 to false, and leave visit ID 2 unchanged as true`() {
+    // Stub two visits with booking ID 1L, with visit IDs 1L and 2L, current term true and false
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber = PENTONVILLE_PRISONER.number, bookingId = 1L))
+      .thenReturn(
+        listOf(
+          createAVisitEntity(1L).apply {
+            offenderBookId = 1L
+            currentTerm = false
+          },
+          createAVisitEntity(2L).apply {
+            offenderBookId = 1L
+            currentTerm = true
+          },
+        ),
+      )
+
+    // Stub one visit with bookingId 2L and current term true
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber = PENTONVILLE_PRISONER.number, bookingId = 1L))
+      .thenReturn(
+        listOf(
+          createAVisitEntity(3L).apply {
+            offenderBookId = 2L
+            currentTerm = true
+          },
+        ),
+      )
+
+    currentTermComponent.processCurrentTermMarkers(PENTONVILLE_PRISONER.number, "PRISONER MERGED")
+
+    verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
+    )
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
+    )
+
+    val visitCaptor = argumentCaptor<OfficialVisitEntity>()
+
+    verify(officialVisitRepository, times(2)).saveAndFlush(visitCaptor.capture())
+
+    with(visitCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
+      assertThat(offenderBookId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(prisonCode).isEqualTo(PENTONVILLE)
+      assertThat(currentTerm).isEqualTo(true)
+    }
+
+    with(visitCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
+      assertThat(offenderBookId).isEqualTo(2L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(prisonCode).isEqualTo(PENTONVILLE)
+      assertThat(currentTerm).isEqualTo(false)
+    }
+
+    val auditEventCaptor = argumentCaptor<AuditEventDto>()
+
+    verify(auditingService, times(2)).recordAuditEvent(auditEventCaptor.capture())
+
+    with(auditEventCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(prisonCode).isEqualTo(PENTONVILLE)
+      assertThat(eventSource).isEqualTo("NOMIS")
+      assertThat(summaryText).isEqualTo("Current term marker updated to true")
+    }
+
+    with(auditEventCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(prisonCode).isEqualTo(PENTONVILLE)
+      assertThat(eventSource).isEqualTo("NOMIS")
+      assertThat(summaryText).isEqualTo("Current term marker updated to false")
+    }
+  }
+
+  @Test
+  fun `should not update current term markers for visits which already have the correct values`() {
+    // Stub two visits with booking ID 1L, visit IDs 1L and 2L, current term both true - already correct
+    whenever(
+      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(
+        prisonerNumber = PENTONVILLE_PRISONER.number,
+        bookingId = 1L,
+      ),
+    )
+      .thenReturn(
+        listOf(
+          createAVisitEntity(1L).apply {
+            offenderBookId = 1L
+            currentTerm = true
+          },
+          createAVisitEntity(2L).apply {
+            offenderBookId = 1L
+            currentTerm = true
+          },
+        ),
+      )
+
+    // Stub one visit with booking ID 2L, visit ID 3L, and current term false - already correct
+    whenever(
+      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(
+        prisonerNumber = PENTONVILLE_PRISONER.number,
+        bookingId = 1L,
+      ),
+    )
+      .thenReturn(
+        listOf(
+          createAVisitEntity(3L).apply {
+            offenderBookId = 2L
+            currentTerm = false
+          },
+        ),
+      )
+
+    currentTermComponent.processCurrentTermMarkers(PENTONVILLE_PRISONER.number, "BOOKING MOVED EVENT")
+
+    verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
+    )
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
+    )
+
+    // Verify no save and no audit recorded
+    verifyNoMoreInteractions(officialVisitRepository)
+    verifyNoInteractions(auditingService)
+  }
+
+  @Test
+  fun `should update current term marker for visit ID's 1,2,3 and 4 to true and none to false`() {
+    // Stub four visits with booking ID 1L, with visit IDs 1L, 2L, 3L, 4L and 2L, all with incorrect current term markers
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber = PENTONVILLE_PRISONER.number, bookingId = 1L))
+      .thenReturn(
+        listOf(
+          createAVisitEntity(1L).apply {
+            offenderBookId = 1L
+            currentTerm = false
+          },
+          createAVisitEntity(2L).apply {
+            offenderBookId = 1L
+            currentTerm = false
+          },
+          createAVisitEntity(3L).apply {
+            offenderBookId = 1L
+            currentTerm = false
+          },
+          createAVisitEntity(4L).apply {
+            offenderBookId = 1L
+            currentTerm = false
+          },
+        ),
+      )
+
+    // No visits with booking IDs that is not 1L
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(prisonerNumber = PENTONVILLE_PRISONER.number, bookingId = 1L))
+      .thenReturn(emptyList())
+
+    currentTermComponent.processCurrentTermMarkers(PENTONVILLE_PRISONER.number, "BOOKING DELETED EVENT")
+
+    verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
+    )
+
+    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(
+      prisonerNumber = PENTONVILLE_PRISONER.number,
+      bookingId = 1L,
+    )
+
+    val visitCaptor = argumentCaptor<OfficialVisitEntity>()
+
+    verify(officialVisitRepository, times(4)).saveAndFlush(visitCaptor.capture())
+
+    with(visitCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
+      assertThat(offenderBookId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(currentTerm).isEqualTo(true)
+    }
+
+    with(visitCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(2L)
+      assertThat(offenderBookId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(currentTerm).isEqualTo(true)
+    }
+
+    with(visitCaptor.thirdValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
+      assertThat(offenderBookId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(currentTerm).isEqualTo(true)
+    }
+
+    with(visitCaptor.lastValue) {
+      assertThat(officialVisitId).isEqualTo(4L)
+      assertThat(offenderBookId).isEqualTo(1L)
+      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
+      assertThat(currentTerm).isEqualTo(true)
+    }
+
+    val auditEventCaptor = argumentCaptor<AuditEventDto>()
+
+    verify(auditingService, times(4)).recordAuditEvent(auditEventCaptor.capture())
+
+    with(auditEventCaptor.firstValue) {
+      assertThat(officialVisitId).isEqualTo(1L)
+      assertThat(summaryText).isEqualTo("Current term marker updated to true")
+    }
+
+    with(auditEventCaptor.secondValue) {
+      assertThat(officialVisitId).isEqualTo(2L)
+      assertThat(summaryText).isEqualTo("Current term marker updated to true")
+    }
+
+    with(auditEventCaptor.thirdValue) {
+      assertThat(officialVisitId).isEqualTo(3L)
+      assertThat(summaryText).isEqualTo("Current term marker updated to true")
+    }
+
+    with(auditEventCaptor.lastValue) {
+      assertThat(officialVisitId).isEqualTo(4L)
+      assertThat(summaryText).isEqualTo("Current term marker updated to true")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingDeletedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingDeletedEventHandlerTest.kt
@@ -1,47 +1,54 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.CurrentTermComponent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerBookingDeletedEventHandler
-import java.time.LocalDateTime
 
 class PrisonerBookingDeletedEventHandlerTest {
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val auditingService: AuditingService = mock()
+  private val currentTermComponent: CurrentTermComponent = mock()
 
-  private val handler = PrisonerBookingDeletedEventHandler(officialVisitRepository, auditingService)
+  private val handler = PrisonerBookingDeletedEventHandler(officialVisitRepository, auditingService, currentTermComponent)
 
   @Test
-  fun `should update visits and set current term for a booking deleted event`() {
-    val bookingStartDateTime = LocalDateTime.now()
-
+  fun `should record an audit event and process current term markers for a booking deleted event`() {
     val bookingDeletedEvent = PrisonerBookingDeletedEvent(
       BookingDeletedInformation("1"),
       PersonReference(listOf(PersonIdentifier(Identifier.NOMS, "ABC222"))),
     )
 
-    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdAndCreatedTimeGreaterThanEqual("ABC222", 1L, bookingStartDateTime)).thenReturn(
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId("ABC222", 1L)).thenReturn(
       listOf(createAVisitEntity(1L), createAVisitEntity(2L)),
     )
 
     handler.handle(bookingDeletedEvent)
+
+    verify(auditingService, times(2)).recordAuditEvent(any())
+    verify(currentTermComponent).processCurrentTermMarkers("ABC222", "BOOKING DELETED EVENT")
   }
 
   @Test
-  fun `should not try to update visits when the count for prisoner number and booking ID is zero`() {
-    val bookingStartDateTime = LocalDateTime.now()
-
+  fun `should not record an audit event but will still process current term markers`() {
     val bookingDeletedEvent = PrisonerBookingDeletedEvent(
       BookingDeletedInformation("1"),
       PersonReference(listOf(PersonIdentifier(Identifier.NOMS, "ABC222"))),
     )
 
-    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdAndCreatedTimeGreaterThanEqual("ABC222", 1L, bookingStartDateTime)).thenReturn(emptyList())
+    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId("ABC222", 1L)).thenReturn(emptyList())
 
     handler.handle(bookingDeletedEvent)
+
+    verifyNoInteractions(auditingService)
+    verify(currentTermComponent).processCurrentTermMarkers("ABC222", "BOOKING DELETED EVENT")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingMovedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingMovedEventHandlerTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.CurrentTermComponent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerBookingMovedEventHandler
 import java.time.LocalDateTime
 
@@ -19,12 +20,13 @@ class PrisonerBookingMovedEventHandlerTest {
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val prisonerVisitedRepository: PrisonerVisitedRepository = mock()
   private val auditingService: AuditingService = mock()
+  private val currentTermComponent: CurrentTermComponent = mock()
 
-  private val handler = PrisonerBookingMovedEventHandler(officialVisitRepository, prisonerVisitedRepository, auditingService)
+  private val handler = PrisonerBookingMovedEventHandler(officialVisitRepository, prisonerVisitedRepository, auditingService, currentTermComponent)
 
   @Test
-  fun `should update visits and prisoner visited for a booking move event`() {
-    val bookingStartDateTime = LocalDateTime.now()
+  fun `should process a booking moved event and update visits`() {
+    val bookingStartDateTime = LocalDateTime.now().minusDays(1)
 
     val bookingMoveEvent = PrisonerBookingMovedEvent(
       BookingMovedInformation("ABC222", "ABC111", "1", bookingStartDateTime),
@@ -39,10 +41,12 @@ class PrisonerBookingMovedEventHandlerTest {
     verify(officialVisitRepository).bookingMove("ABC222", "ABC111", 1L, bookingStartDateTime)
     verify(prisonerVisitedRepository).replacePrisonerNumberForBooking("ABC222", "ABC111", 1L, bookingStartDateTime)
     verify(auditingService, times(2)).recordAuditEvent(any())
+    verify(currentTermComponent).processCurrentTermMarkers("ABC222", "BOOKING MOVED EVENT")
+    verify(currentTermComponent).processCurrentTermMarkers("ABC111", "BOOKING MOVED EVENT")
   }
 
   @Test
-  fun `should not try to update visits when the count for prisoner number and booking ID is zero`() {
+  fun `should not update visits when none are affected by the booking move event`() {
     val bookingStartDateTime = LocalDateTime.now()
 
     val bookingMoveEvent = PrisonerBookingMovedEvent(
@@ -57,5 +61,7 @@ class PrisonerBookingMovedEventHandlerTest {
 
     verifyNoMoreInteractions(officialVisitRepository)
     verifyNoInteractions(prisonerVisitedRepository)
+    verify(currentTermComponent).processCurrentTermMarkers("ABC222", "BOOKING MOVED EVENT")
+    verify(currentTermComponent).processCurrentTermMarkers("ABC111", "BOOKING MOVED EVENT")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
@@ -6,17 +6,19 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.CurrentTermComponent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerMergedEventHandler
 
 class PrisonerMergedEventHandlerTest {
   private val removedPrisonerNumber = "A1234AA"
   private val retainedPrisonerNumber = "A1234BB"
+
   private val mergeEvent = PrisonerMergedEvent(
     additionalInformation = MergeInformation(
       nomsNumber = retainedPrisonerNumber,
@@ -27,11 +29,17 @@ class PrisonerMergedEventHandlerTest {
   private val officialVisitRepository: OfficialVisitRepository = mock()
   private val prisonerVisitedRepository: PrisonerVisitedRepository = mock()
   private val auditingService: AuditingService = mock()
+  private val currentTermComponent: CurrentTermComponent = mock()
 
-  private val handler = PrisonerMergedEventHandler(officialVisitRepository, prisonerVisitedRepository, auditingService)
+  private val handler = PrisonerMergedEventHandler(
+    officialVisitRepository,
+    prisonerVisitedRepository,
+    auditingService,
+    currentTermComponent,
+  )
 
   @Test
-  fun `should merge old prisoner with new prisoner`() {
+  fun `should process a prisoner merge event and update visits`() {
     whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(
       listOf(
         createAVisitEntity(1L),
@@ -39,75 +47,25 @@ class PrisonerMergedEventHandlerTest {
       ),
     )
 
-    // No current term markers to update
-    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)).thenReturn(emptyList())
-    whenever(officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)).thenReturn(emptyList())
-
     handler.handle(mergeEvent)
 
-    // Should be 2 visit updates
+    verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
     verify(officialVisitRepository, times(2)).saveAndFlush(any())
-
-    // One replacement of prisoner visited
-    verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
-
-    // Check the current term markers - once each
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
-
-    // Record updates on 2 visits
     verify(auditingService, times(2)).recordAuditEvent(any())
+    verify(currentTermComponent).processCurrentTermMarkers(retainedPrisonerNumber, "PRISONER MERGED EVENT")
   }
 
   @Test
-  fun `should merge and update current term marker on an existing visit`() {
-    // One visit to update
-    whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(
-      listOf(createAVisitEntity(1L)),
-    )
-
-    // One current term marker to update to true
-    whenever(
-      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(
-        retainedPrisonerNumber,
-        MOORLAND_PRISONER.bookingId,
-      ),
-    ).thenReturn(listOf(createAVisitEntity(2L).apply { currentTerm = false }))
-
-    // One current term marker to update to false
-    whenever(
-      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(
-        retainedPrisonerNumber,
-        MOORLAND_PRISONER.bookingId,
-      ),
-    ).thenReturn(listOf(createAVisitEntity(3L).apply { currentTerm = true }))
-
-    handler.handle(mergeEvent)
-
-    // Should be 3 visits updated (one for the prisoner number, 2 for the current term markers)
-    verify(officialVisitRepository, times(3)).saveAndFlush(any())
-
-    // One call to prisoner visited
-    verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
-
-    // Called once each
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
-
-    // Called 3 times - once for the visit update, twice for current term updates
-    verify(auditingService, times(3)).recordAuditEvent(any())
-  }
-
-  @Test
-  fun `should not call merge when no official visits exist for the removed prisoner number`() {
+  fun `should process a prisoner merge event but find no visits are affected`() {
     whenever(officialVisitRepository.findAllByPrisonerNumber(removedPrisonerNumber)).thenReturn(emptyList())
 
     handler.handle(mergeEvent)
 
     verify(officialVisitRepository).findAllByPrisonerNumber(removedPrisonerNumber)
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(retainedPrisonerNumber, MOORLAND_PRISONER.bookingId)
+    verifyNoMoreInteractions(officialVisitRepository)
 
     verifyNoInteractions(prisonerVisitedRepository, auditingService)
+
+    verify(currentTermComponent).processCurrentTermMarkers(retainedPrisonerNumber, "PRISONER MERGED EVENT")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerReceivedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerReceivedEventHandlerTest.kt
@@ -1,29 +1,16 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound
 
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.whenever
-import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerSearchClient
-import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.PENTONVILLE_PRISONER
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.createAVisitEntity
-import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.prisonerSearchPrisoner
-import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditEventDto
-import uk.gov.justice.digital.hmpps.officialvisitsapi.service.auditing.AuditingService
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.CurrentTermComponent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound.handlers.PrisonerReceivedEventHandler
 
 class PrisonerReceivedEventHandlerTest {
-  private val officialVisitRepository: OfficialVisitRepository = mock()
-  private val auditingService: AuditingService = mock()
-  private val prisonerSearchClient: PrisonerSearchClient = mock()
+  private val currentTermComponent: CurrentTermComponent = mock()
 
   // Indicates received on a new booking ID
   private val newBookingEvent = PrisonerReceivedEvent(
@@ -52,173 +39,23 @@ class PrisonerReceivedEventHandlerTest {
     ),
   )
 
-  private val handler = PrisonerReceivedEventHandler(officialVisitRepository, auditingService, prisonerSearchClient)
+  private val handler = PrisonerReceivedEventHandler(currentTermComponent)
 
-  @BeforeEach
-  fun setup() {
-    whenever(
-      prisonerSearchClient.getPrisoner(PENTONVILLE_PRISONER.number),
-    ).thenReturn(
-      prisonerSearchPrisoner(
-        prisonerNumber = PENTONVILLE_PRISONER.number,
-        prisonCode = PENTONVILLE_PRISONER.prison,
-        bookingId = PENTONVILLE_PRISONER.bookingId, // BookingId = 1L
-      ),
-    )
-
-    whenever(
-      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(
-        prisonerNumber = PENTONVILLE_PRISONER.number,
-        bookingId = 1L,
-      ),
-    ).thenReturn(
-      listOf(
-        createAVisitEntity(1L).apply {
-          offenderBookId = 1L
-          currentTerm = false
-        },
-        createAVisitEntity(2L).apply {
-          offenderBookId = 1L
-          currentTerm = true
-        },
-      ),
-    )
-
-    whenever(
-      officialVisitRepository.findAllByPrisonerNumberAndOffenderBookIdNot(
-        prisonerNumber = PENTONVILLE_PRISONER.number,
-        bookingId = 1L,
-      ),
-    ).thenReturn(
-      listOf(
-        createAVisitEntity(3L).apply {
-          offenderBookId = 2L
-          currentTerm = true
-        },
-      ),
-    )
-  }
-
-  /**
-   * This test should update bookingIds 1 and 3, but leave 2 unchanged, as its current term
-   * marker is already correct for the circumstances.
-   */
   @Test
-  fun `should manage the currentTerm markers on visits for a NEW_ADMISSION event`() {
+  fun `should adjust the currentTerm markers on visits for a NEW_ADMISSION event`() {
     handler.handle(newBookingEvent)
-
-    verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
-
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(
-      prisonerNumber = PENTONVILLE_PRISONER.number,
-      bookingId = 1L,
-    )
-
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(
-      prisonerNumber = PENTONVILLE_PRISONER.number,
-      bookingId = 1L,
-    )
-
-    val visitCaptor = argumentCaptor<OfficialVisitEntity>()
-
-    verify(officialVisitRepository, times(2)).saveAndFlush(visitCaptor.capture())
-
-    with(visitCaptor.firstValue) {
-      assertThat(officialVisitId).isEqualTo(1L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(currentTerm).isEqualTo(true)
-    }
-
-    with(visitCaptor.secondValue) {
-      assertThat(officialVisitId).isEqualTo(3L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(currentTerm).isEqualTo(false)
-    }
-
-    val auditEventCaptor = argumentCaptor<AuditEventDto>()
-
-    verify(auditingService, times(2)).recordAuditEvent(auditEventCaptor.capture())
-
-    with(auditEventCaptor.firstValue) {
-      assertThat(officialVisitId).isEqualTo(1L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
-    }
-
-    with(auditEventCaptor.secondValue) {
-      assertThat(officialVisitId).isEqualTo(3L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
-    }
+    verify(currentTermComponent).processCurrentTermMarkers(PENTONVILLE_PRISONER.number, "PRISONER RECEIVED EVENT")
   }
 
-  /**
-   * This test should update bookingIds 1 and 3, but leave 2 unchanged, as its current term
-   * marker is already correct for the circumstances.
-   */
   @Test
-  fun `should manage the currentTerm markers on visits for a READMISSION_SWITCH_BOOKING event`() {
+  fun `should adjust the currentTerm markers on visits for a READMISSION_SWITCH_BOOKING event`() {
     handler.handle(newSwitchBookingEvent)
-
-    verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
-
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookId(
-      prisonerNumber = PENTONVILLE_PRISONER.number,
-      bookingId = 1L,
-    )
-
-    verify(officialVisitRepository).findAllByPrisonerNumberAndOffenderBookIdNot(
-      prisonerNumber = PENTONVILLE_PRISONER.number,
-      bookingId = 1L,
-    )
-
-    val visitCaptor = argumentCaptor<OfficialVisitEntity>()
-
-    verify(officialVisitRepository, times(2)).saveAndFlush(visitCaptor.capture())
-
-    with(visitCaptor.firstValue) {
-      assertThat(officialVisitId).isEqualTo(1L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(currentTerm).isEqualTo(true)
-    }
-
-    with(visitCaptor.secondValue) {
-      assertThat(officialVisitId).isEqualTo(3L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(currentTerm).isEqualTo(false)
-    }
-
-    val auditEventCaptor = argumentCaptor<AuditEventDto>()
-
-    verify(auditingService, times(2)).recordAuditEvent(auditEventCaptor.capture())
-
-    with(auditEventCaptor.firstValue) {
-      assertThat(officialVisitId).isEqualTo(1L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
-    }
-
-    with(auditEventCaptor.secondValue) {
-      assertThat(officialVisitId).isEqualTo(3L)
-      assertThat(prisonerNumber).isEqualTo(PENTONVILLE_PRISONER.number)
-      assertThat(prisonCode).isEqualTo(PENTONVILLE)
-      assertThat(summaryText).isEqualTo("The visit current term marker has been updated due to a new booking")
-    }
+    verify(currentTermComponent).processCurrentTermMarkers(PENTONVILLE_PRISONER.number, "PRISONER RECEIVED EVENT")
   }
 
   @Test
-  fun `should not attempt to set the currentTerm marker to false when a new booking is not created`() {
+  fun `should not attempt to adjust the currentTerm markers when a new booking is not created`() {
     handler.handle(sameBookingEvent)
-
-    verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
-    verifyNoInteractions(officialVisitRepository)
-    verifyNoInteractions(auditingService)
+    verifyNoInteractions(currentTermComponent)
   }
 }


### PR DESCRIPTION
This PR:
* Implements the booked.deleted (new) event
* Fully implements the booking.moved event, with advice received from Syscon.
* Refactors all event handlers to use a common component for managing current term markers on visits.
* Includes full testing for the new component and event handlers.

Previously each event handler had its own implementation for the management of current term markers which was creating quite a lot of duplication. Better to abstract into a common component and add more rigorous tests around that.