### PR TITLE
OV-766: make visit_type a significant audit change

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingService.kt
@@ -160,7 +160,7 @@ class AuditingService(
       )
     }
 
-  private fun isSignificantChange(field: String) = listOf("visit_date", "start_time", "end_time", "location", "visit_status").contains(field)
+  private fun isSignificantChange(field: String) = listOf("visit_date", "start_time", "end_time", "location", "visit_status", "visit_type").contains(field)
 
   fun recordAuditEvent(auditEvent: AuditEventDto) {
     auditedEventRepository.saveAndFlush(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/auditing/AuditingServiceTest.kt
@@ -92,6 +92,37 @@ class AuditingServiceTest {
   }
 
   @Test
+  fun `should map audited updated visit type event as a significant change`() {
+    val updatedEvent = event(
+      auditEventId = 101,
+      summaryText = "Visit updated",
+      detailText = "visit_type|VIDEO|TELEPHONE;",
+    )
+
+    whenever(auditedEventRepository.findAllByOfficialVisitId(visitId)) doReturn listOf(updatedEvent)
+
+    val event = auditingService.findByOfficialVisitId(visitId).single()
+
+    with(event) {
+      auditedEventId isEqualTo 101L
+      officialVisitId isEqualTo visitId
+      eventType isEqualTo "UPDATE"
+      eventSummary isEqualTo "Visit updated"
+      eventSource isEqualTo "DPS"
+      eventDateTime isEqualTo updatedEvent.eventDateTime
+      eventUsername isEqualTo updatedEvent.userName
+      eventUserFullName isEqualTo updatedEvent.userFullName
+      significantChange isBool true
+      eventChanges.containsExactly(
+        listOf(
+          AuditedEventChange(field = "visit_type", oldValue = "VIDEO", newValue = "TELEPHONE", true),
+        ),
+      )
+      eventVersion isEqualTo 2
+    }
+  }
+
+  @Test
   fun `should map audited update event without significant changes correctly`() {
     val updatedEvent = event(
       auditEventId = 101,


### PR DESCRIPTION
Usually, when you change the visit type you would select a different time or location, but it's possible to change it and keep the same time and location if that location supports both types. Therefore changing the visit type needs to be considered significant, so that email reminders will be given.