### PR TITLE
OV-769: Introduce a check for the bookingId returned from prisoner search.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/CurrentTermComponent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/CurrentTermComponent.kt
@@ -29,13 +29,22 @@ class CurrentTermComponent(
   }
 
   @Transactional
-  fun processCurrentTermMarkers(prisonerNumber: String, source: String) {
+  fun processCurrentTermMarkers(prisonerNumber: String, source: String, checkBookingId: Long? = null) {
     var currentTermCounter = 0
     var previousTermCounter = 0
 
     // Get the current bookingId for this prisoner
     val prisoner = prisonerSearchClient.getPrisoner(prisonerNumber)
       ?: throw EntityNotFoundException("Prisoner not found $prisonerNumber")
+
+    // Check for prisoner search with a different booking ID than the check booking ID (only merges and booking moves provide this)
+    // If the check fails this transaction is rolled back and the event will be retried from DLQ later.
+    checkBookingId?.let {
+      if (checkBookingId != prisoner.bookingId!!.toLong()) {
+        log.info("Event $source - Prisoner search $prisonerNumber current booking ${prisoner.bookingId} is different than event booking $checkBookingId")
+        throw RuntimeException("Event $source - Prisoner search $prisonerNumber booking ${prisoner.bookingId} is different from event booking $checkBookingId")
+      }
+    }
 
     // Find visits that match the prisoner number and current bookingId, if currentTerm = false set it to true
     officialVisitRepository.findAllByPrisonerNumberAndOffenderBookId(prisonerNumber, prisoner.bookingId!!.toLong())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingMovedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerBookingMovedEventHandler.kt
@@ -63,8 +63,11 @@ class PrisonerBookingMovedEventHandler(
       }
     }
 
-    // Check and reset current term markers for both prisoner numbers, which may or may not be affected
+    // For the new prisoner number - add the check bookingId from the event - it will fail if prisoner search reports a different bookingId
+    // On failure, the event will go onto the DLQ and be retried until prisoner search is reporting the same bookingId
+    currentTermComponent.processCurrentTermMarkers(movedToNomsNumber, "BOOKING MOVED EVENT", bookingId)
+
+    // For the old prisoner number - rely on prisoner search to tell us the latest bookingId and reset current term accordingly
     currentTermComponent.processCurrentTermMarkers(movedFromNomsNumber, "BOOKING MOVED EVENT")
-    currentTermComponent.processCurrentTermMarkers(movedToNomsNumber, "BOOKING MOVED EVENT")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/handlers/PrisonerMergedEventHandler.kt
@@ -56,6 +56,7 @@ class PrisonerMergedEventHandler(
     }
 
     // Check and update the current term markers on visits for the new prisoner only (the old prisoner number is removed)
-    currentTermComponent.processCurrentTermMarkers(newPrisonerNumber, "PRISONER MERGED EVENT")
+    // This event provides a booking ID to check against the prisoner search bookingId - will throw an exception if different.
+    currentTermComponent.processCurrentTermMarkers(newPrisonerNumber, "PRISONER MERGED EVENT", bookingId.toLong())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/CurrentTermComponentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/CurrentTermComponentTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.service.events.inbound
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -293,5 +294,22 @@ class CurrentTermComponentTest {
       assertThat(summaryText).isEqualTo("Current term changed")
       assertThat(detailText).isEqualTo("current_term|false|true")
     }
+  }
+
+  @Test
+  fun `should throw a runtime exception if prisoner search reports a different booking ID than the checkBookingId`() {
+    // Provides a checkBookingId that is different from the prisoner search stub reports (1L)
+    val exception = assertThrows<RuntimeException> {
+      currentTermComponent.processCurrentTermMarkers(PENTONVILLE_PRISONER.number, "PRISONER MERGED EVENT", 2L)
+    }
+
+    assertThat(exception.message).isEqualTo(
+      "Event PRISONER MERGED EVENT - Prisoner search ${PENTONVILLE_PRISONER.number} booking 1 is different from event booking 2",
+    )
+
+    verify(prisonerSearchClient).getPrisoner(PENTONVILLE_PRISONER.number)
+
+    verifyNoInteractions(officialVisitRepository)
+    verifyNoInteractions(auditingService)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingMovedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerBookingMovedEventHandlerTest.kt
@@ -41,8 +41,8 @@ class PrisonerBookingMovedEventHandlerTest {
     verify(officialVisitRepository).bookingMove("ABC222", "ABC111", 1L, bookingStartDateTime)
     verify(prisonerVisitedRepository).replacePrisonerNumberForBooking("ABC222", "ABC111", 1L, bookingStartDateTime)
     verify(auditingService, times(2)).recordAuditEvent(any())
+    verify(currentTermComponent).processCurrentTermMarkers("ABC111", "BOOKING MOVED EVENT", bookingMoveEvent.bookingId().toLong())
     verify(currentTermComponent).processCurrentTermMarkers("ABC222", "BOOKING MOVED EVENT")
-    verify(currentTermComponent).processCurrentTermMarkers("ABC111", "BOOKING MOVED EVENT")
   }
 
   @Test
@@ -61,7 +61,7 @@ class PrisonerBookingMovedEventHandlerTest {
 
     verifyNoMoreInteractions(officialVisitRepository)
     verifyNoInteractions(prisonerVisitedRepository)
+    verify(currentTermComponent).processCurrentTermMarkers("ABC111", "BOOKING MOVED EVENT", bookingMoveEvent.bookingId().toLong())
     verify(currentTermComponent).processCurrentTermMarkers("ABC222", "BOOKING MOVED EVENT")
-    verify(currentTermComponent).processCurrentTermMarkers("ABC111", "BOOKING MOVED EVENT")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/events/inbound/PrisonerMergedEventHandlerTest.kt
@@ -52,7 +52,11 @@ class PrisonerMergedEventHandlerTest {
     verify(prisonerVisitedRepository).replacePrisonerNumber(removedPrisonerNumber, retainedPrisonerNumber)
     verify(officialVisitRepository, times(2)).saveAndFlush(any())
     verify(auditingService, times(2)).recordAuditEvent(any())
-    verify(currentTermComponent).processCurrentTermMarkers(retainedPrisonerNumber, "PRISONER MERGED EVENT")
+    verify(currentTermComponent).processCurrentTermMarkers(
+      prisonerNumber = retainedPrisonerNumber,
+      source = "PRISONER MERGED EVENT",
+      checkBookingId = mergeEvent.additionalInformation.bookingId.toLong(),
+    )
   }
 
   @Test
@@ -66,6 +70,10 @@ class PrisonerMergedEventHandlerTest {
 
     verifyNoInteractions(prisonerVisitedRepository, auditingService)
 
-    verify(currentTermComponent).processCurrentTermMarkers(retainedPrisonerNumber, "PRISONER MERGED EVENT")
+    verify(currentTermComponent).processCurrentTermMarkers(
+      prisonerNumber = retainedPrisonerNumber,
+      source = "PRISONER MERGED EVENT",
+      checkBookingId = mergeEvent.additionalInformation.bookingId.toLong(),
+    )
   }
 }


### PR DESCRIPTION
For booking moves and offender merge domain events, the event received contains the latest bookingId. This PR uses this booking ID on the event to confirm whether prisoner-search indexes have been updated or not. If not, it will fail the handling of the event, and it will be retried. 

This is to overcome the race condition that exists between offender events being and the prisoner search indexes being updated.