### PR TITLE
OV-763 : fix email alert when no notifications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsService.kt
@@ -105,7 +105,7 @@ class NotificationsService(
   @Transactional(readOnly = true)
   fun checkVisitChangedSinceLastNotification(officialVisitId: Long): VisitChangeStatusResponse {
     val lastNotification = notificationRepository.findTopByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId)
-      ?: return VisitChangeStatusResponse(hasChanged = false)
+      ?: return VisitChangeStatusResponse(hasChanged = true)
 
     val significantEventCount = auditingService.findByOfficialVisitId(officialVisitId)
       .filter { it.eventDateTime > lastNotification.createdTime }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationOfChangesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationOfChangesIntegrationTest.kt
@@ -112,12 +112,12 @@ class NotificationOfChangesIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should return false when no notifications have been sent for the visit`() {
+  fun `should return true when no notifications have been sent for the visit`() {
     val scheduledVisit = testAPIClient.createOfficialVisit(nextMondayAt9, MOORLAND_PRISON_USER)
 
     val response = webTestClient.getVisitChangedSinceLastNotification(scheduledVisit.officialVisitId)
 
-    response.hasChanged isEqualTo false
+    response.hasChanged isEqualTo true
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationsServiceTest.kt
@@ -342,12 +342,12 @@ class NotificationsServiceTest {
     }
 
     @Test
-    fun `should return false when no notifications exist for the visit`() {
+    fun `should return true when no notifications exist for the visit`() {
       whenever { notificationRepository.findTopByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId) } doReturn null
 
       val result = service.checkVisitChangedSinceLastNotification(officialVisitId)
 
-      result.hasChanged isBool false
+      result.hasChanged isBool true
       verify(notificationRepository).findTopByOfficialVisitIdOrderByCreatedTimeDesc(officialVisitId)
       verifyNoInteractions(auditingService)
     }


### PR DESCRIPTION
Convert GOV.UK Notify callback timestamps to the system default timezone

GOV.UK Notify returns callback timestamps in UTC (with timezone information), while the application stores system-generated timestamps using `LocalDateTime.now()`, which uses the system default timezone.

This change converts the `completedAt` timestamp from the Notify callback to the system default timezone before persisting it. This keeps externally sourced timestamps consistent with timestamps generated within the application and prevents apparent time discrepancies, such as `statusUpdatedTime` appearing earlier than `createdTime` for the same notification.
