### PR TITLE
OV-767 : update notification timestamps to use OffsetDateTime

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/NotifyCallbackNotificationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/request/NotifyCallbackNotificationRequest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.officialvisitsapi.model.request
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.util.*
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -19,13 +19,13 @@ data class NotifyCallbackNotificationRequest(
   val status: String,
   @param:Schema(description = "The timestamp for when the vsip notification service sent the notification to gov notify", required = true)
   @param:JsonAlias("created_at")
-  val createdAt: LocalDateTime,
+  val createdAt: OffsetDateTime,
   @param:Schema(description = "The timestamp for the final update of the notification (when delivered or ultimately failed) ", required = false)
   @param:JsonAlias("completed_at")
-  val completedAt: LocalDateTime?,
+  val completedAt: OffsetDateTime?,
   @param:Schema(description = "The timestamp for when gov notify sent the notification", required = false)
   @param:JsonAlias("sent_at")
-  val sentAt: LocalDateTime?,
+  val sentAt: OffsetDateTime?,
   @param:Schema(description = "The email or phone number the notification was sent to", required = true)
   @param:JsonAlias("to")
   val sentTo: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationCallbackService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationCallbackService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEmailSt
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotifyCallbackNotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Component
 class NotificationCallbackService(
@@ -27,12 +28,16 @@ class NotificationCallbackService(
 
     val notification = notificationRepository.findByGovNotifyNotificationId(request.notificationId)
     if (notification == null) {
-      logger.warn("Received GOV.UK Notify callback for unknown notification id {}", request.notificationId)
+      logger.warn("Received GOV.UK Notify callback for unknown notification id {} and completed time {}", request.notificationId, request.completedAt)
       return
     }
 
     notification.emailStatus = request.status.toEmailStatus()
-    notification.statusUpdatedTime = request.completedAt ?: LocalDateTime.now()
+    notification.statusUpdatedTime =
+      request.completedAt
+        ?.atZoneSameInstant(ZoneId.systemDefault())
+        ?.toLocalDateTime()
+        ?: LocalDateTime.now()
 
     logger.info(
       "Processed GOV.UK Notify callback for notification id {} with status {}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationCallbackIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/NotificationCallbackIntegrationTest.kt
@@ -90,8 +90,9 @@ class NotificationCallbackIntegrationTest : IntegrationTestBase() {
       {
         "id": "$notificationId",
         "status": "$status",
-        "created_at": "2026-05-28T09:00:00",
-        "sent_at": "2026-05-28T09:05:00",
+        "created_at": "2026-05-28T09:00:00.000000Z",
+        "completed_at": "2026-06-23T13:27:11.835723Z",
+        "sent_at": "2026-05-28T09:05:00.000000Z",
         "to": "email@address.com",
         "notification_type": "email",
         "template_id": "${UUID.randomUUID()}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationCallbackServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/notifications/NotificationCallbackServiceTest.kt
@@ -11,6 +11,8 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.NotificationEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.NotifyCallbackNotificationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.NotificationRepository
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.util.UUID
 
 class NotificationCallbackServiceTest {
@@ -29,7 +31,7 @@ class NotificationCallbackServiceTest {
       govNotifyNotificationId = notificationId,
       createdTime = LocalDateTime.now(),
     )
-    val completedAt = LocalDateTime.parse("2026-05-28T10:15:00")
+    val completedAt = OffsetDateTime.parse("2026-06-23T13:27:11.835723Z")
 
     whenever(repository.findByGovNotifyNotificationId(notificationId)) doReturn notification
 
@@ -39,7 +41,9 @@ class NotificationCallbackServiceTest {
 
     verify(repository).findByGovNotifyNotificationId(notificationId)
     assertThat(notification.emailStatus).isEqualTo(NotificationEmailStatus.SENT)
-    assertThat(notification.statusUpdatedTime).isEqualTo(completedAt)
+    assertThat(notification.statusUpdatedTime).isEqualTo(
+      completedAt.atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime(),
+    )
   }
 
   @Test
@@ -74,14 +78,14 @@ class NotificationCallbackServiceTest {
   private fun callbackRequest(
     notificationId: UUID,
     status: String,
-    completedAt: LocalDateTime? = null,
+    completedAt: OffsetDateTime? = null,
   ) = NotifyCallbackNotificationRequest(
     notificationId = notificationId,
     eventAuditReference = "event-audit-reference",
     status = status,
-    createdAt = LocalDateTime.parse("2026-05-28T09:00:00"),
+    createdAt = OffsetDateTime.parse("2026-05-28T09:00:00.000000Z"),
     completedAt = completedAt,
-    sentAt = LocalDateTime.parse("2026-05-28T09:05:00"),
+    sentAt = OffsetDateTime.parse("2026-05-28T09:05:00.000000Z"),
     sentTo = "test@example.com",
     notificationType = "email",
     templateId = UUID.randomUUID(),


### PR DESCRIPTION
Convert GOV.UK Notify callback timestamps to the system default timezone

GOV.UK Notify returns callback timestamps in UTC (with timezone information), while the application stores system-generated timestamps using LocalDateTime.now(), which uses the system default timezone.

This change converts the completedAt timestamp from the Notify callback to the system default timezone before persisting it. This keeps externally sourced timestamps consistent with timestamps generated within the application and prevents apparent time discrepancies, such as statusUpdatedTime appearing earlier than createdTime for the same notification.

Documentation from gov notify says:
<img width="1185" height="797" alt="image" src="https://github.com/user-attachments/assets/0f2e926a-3919-463d-a7c2-02c51e79ce7b" />

