### PR TITLE
OV-786 : SAR reports content changes in the API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/sar/SarVisit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/sar/SarVisit.kt
@@ -6,18 +6,13 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitCompletionType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitStatusType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.VisitType
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.LocalTime
-import java.util.UUID
 
 data class SarVisit(
-  val officialVisitId: Long,
   val prisonCode: String,
   val visitDate: LocalDate,
-  val prisonerNumber: String,
   val startTime: LocalTime,
   val endTime: LocalTime,
-  val dpsLocationId: UUID,
   val visitType: VisitType,
   val visitStatus: VisitStatusType,
   val completionCode: VisitCompletionType? = null,
@@ -25,26 +20,13 @@ data class SarVisit(
   val prisonerAttendance: AttendanceType? = null,
   val staffNotes: String? = null,
   val prisonerNotes: String? = null,
+  val searchTypeCode: String? = null,
+  val visitorConcernNotes: String? = null,
   val visitors: List<SarVisitor> = emptyList(),
-  val events: List<SarEvent> = emptyList(),
 )
 
 data class SarVisitor(
-  val officialVisitorId: Long,
-  val firstName: String?,
-  val lastName: String?,
   val relationshipType: RelationshipType? = null,
   val relationshipCode: String? = null,
-  val relationshipDescription: String? = null,
-  val visitorNotes: String? = null,
   val visitorAttendance: AttendanceType? = null,
-)
-
-data class SarEvent(
-  val auditedEventId: Long,
-  val eventDateTime: LocalDateTime,
-  val eventType: String,
-  val eventDescription: String,
-  val staffCode: String,
-  val staffName: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/sar/SarVisit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/sar/SarVisit.kt
@@ -27,6 +27,6 @@ data class SarVisit(
 
 data class SarVisitor(
   val relationshipType: RelationshipType? = null,
-  val relationshipCode: String? = null,
+  val relationshipDescription: String? = null,
   val visitorAttendance: AttendanceType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sar/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sar/SubjectAccessRequestService.kt
@@ -4,11 +4,9 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sar.SarEvent
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sar.SarVisit
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sar.SarVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sar.SubjectAccessResponseData
-import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.AuditedEventRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
@@ -27,7 +25,6 @@ import java.time.LocalDate
 class SubjectAccessRequestService(
   private val officialVisitRepository: OfficialVisitRepository,
   private val prisonerVisitedRepository: PrisonerVisitedRepository,
-  private val auditedEventRepository: AuditedEventRepository,
 ) : HmppsPrisonSubjectAccessRequestService {
 
   companion object {
@@ -54,44 +51,27 @@ class SubjectAccessRequestService(
     log.info("SAR: matches found for prisoner $prn, from $from to $to.")
 
     val sarVisits = officialVisits.map { visit ->
-      val auditEvents = auditedEventRepository.findAllByOfficialVisitId(visit.officialVisitId)
-
       val prisonerVisited = prisonerVisitedRepository.findByOfficialVisit(visit)
 
       SarVisit(
-        officialVisitId = visit.officialVisitId,
-        prisonCode = visit.prisonCode,
-        prisonerNumber = visit.prisonerNumber,
-        visitDate = visit.visitDate,
-        startTime = visit.startTime,
-        endTime = visit.endTime,
-        dpsLocationId = visit.dpsLocationId,
-        visitType = visit.visitTypeCode,
-        visitStatus = visit.visitStatusCode,
         completionCode = visit.completionCode,
-        prisonerAttendance = prisonerVisited?.attendanceCode,
-        staffNotes = visit.staffNotes,
+        completionNotes = visit.completionNotes,
+        endTime = visit.endTime,
+        prisonCode = visit.prisonCode,
         prisonerNotes = visit.prisonerNotes,
+        searchTypeCode = visit.searchTypeCode?.name,
+        staffNotes = visit.staffNotes,
+        startTime = visit.startTime,
+        visitDate = visit.visitDate,
+        visitorConcernNotes = visit.visitorConcernNotes,
+        visitStatus = visit.visitStatusCode,
+        visitType = visit.visitTypeCode,
+        prisonerAttendance = prisonerVisited?.attendanceCode,
         visitors = visit.officialVisitors().map { visitor ->
           SarVisitor(
-            officialVisitorId = visitor.officialVisitorId,
-            firstName = visitor.firstName,
-            lastName = visitor.lastName,
+            visitorAttendance = visitor.attendanceCode,
             relationshipType = visitor.relationshipTypeCode,
             relationshipCode = visitor.relationshipCode,
-            relationshipDescription = "TODO - lookup relationship description",
-            visitorNotes = visitor.visitorNotes,
-            visitorAttendance = visitor.attendanceCode,
-          )
-        },
-        events = auditEvents.map { event ->
-          SarEvent(
-            auditedEventId = event.auditedEventId,
-            eventDateTime = event.eventDateTime,
-            eventType = event.summaryText,
-            eventDescription = event.detailText,
-            staffCode = event.userName,
-            staffName = event.userFullName,
           )
         },
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sar/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/sar/SubjectAccessRequestService.kt
@@ -4,11 +4,13 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.client.personalrelationships.model.ReferenceCodeGroup
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sar.SarVisit
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sar.SarVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.sar.SubjectAccessResponseData
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.service.PersonalRelationshipsReferenceDataService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
 import java.time.LocalDate
@@ -25,6 +27,7 @@ import java.time.LocalDate
 class SubjectAccessRequestService(
   private val officialVisitRepository: OfficialVisitRepository,
   private val prisonerVisitedRepository: PrisonerVisitedRepository,
+  private val personalRelationshipsReferenceDataService: PersonalRelationshipsReferenceDataService,
 ) : HmppsPrisonSubjectAccessRequestService {
 
   companion object {
@@ -71,7 +74,7 @@ class SubjectAccessRequestService(
           SarVisitor(
             visitorAttendance = visitor.attendanceCode,
             relationshipType = visitor.relationshipTypeCode,
-            relationshipCode = visitor.relationshipCode,
+            relationshipDescription = visitor.relationshipCode?.let { personalRelationshipsReferenceDataService.getReferenceDataByCode(getRelationShipCode(visitor.relationshipTypeCode.toString()), visitor.relationshipCode!!)?.description } ?: "No relationship",
           )
         },
       )
@@ -87,5 +90,11 @@ class SubjectAccessRequestService(
         officialVisits = sarVisits,
       ),
     )
+  }
+
+  private fun getRelationShipCode(relationshipTypeCode: String?) = if (relationshipTypeCode == "OFFICIAL") {
+    ReferenceCodeGroup.OFFICIAL_RELATIONSHIP.toString()
+  } else {
+    ReferenceCodeGroup.SOCIAL_RELATIONSHIP.toString()
   }
 }

--- a/src/main/resources/sar/templates/sar_template.mustache
+++ b/src/main/resources/sar/templates/sar_template.mustache
@@ -14,7 +14,6 @@
         <h3>Visit</h3>
         <table class="summary-list">
             <tr><td>Prison name</td><td>{{ getPrisonName prisonCode }}</td></tr>
-            <tr><td>Prisoner number</td><td>{{ optionalString prisonerNumber }}</td></tr>
             <tr><td>Visit date</td><td>{{ formatDate visitDate }}</td></tr>
             <tr><td>Start time</td><td>{{ formatDate startTime }}</td></tr>
             <tr><td>End time</td><td>{{ formatDate endTime }}</td></tr>
@@ -22,36 +21,24 @@
             <tr><td>Visit status</td><td>{{ optionalString visitStatus }}</td></tr>
             <tr><td>Staff notes</td><td>{{ optionalString staffNotes }}</td></tr>
             <tr><td>Prisoner notes</td><td>{{ optionalString prisonerNotes }}</td></tr>
-            <tr><td>Location</td><td>{{ getLocationNameByDpsId dpsLocationId }}</td></tr>
             <tr><td>Attendance</td><td>{{ optionalString prisonerAttendance }}</td></tr>
             <tr><td>Completion type</td><td>{{ optionalString completionCode }}</td></tr>
+            <tr><td>Completion notes</td><td>{{ optionalString completionNotes }}</td></tr>
+            <tr><td>Search type</td><td>{{ optionalString searchTypeCode }}</td></tr>
+            <tr><td>Visitor concern notes</td><td>{{ optionalString visitorConcernNotes }}</td></tr>
         </table>
 
         <h3>Visitors</h3>
         {{#visitors}}
         <table class="summary-list">
-            <tr><td>First name</td><td>{{ optionalString firstName }}</td></tr>
-            <tr><td>Last name</td><td>{{ optionalString lastName }}</td></tr>
-            <tr><td>Relationship code</td><td>{{ optionalString relationshipCode }}</td></tr>
-            <tr><td>Relationship</td><td>{{ optionalString relationshipDescription }}</td></tr>
-            <tr><td>Notes</td><td>{{ optionalString visitorNotes }}</td></tr>
+            <tr><td>Relationship type</td><td>{{ optionalString relationshipType }}</td></tr>
+            <tr><td>Relationship</td><td>{{ optionalString relationshipCode }}</td></tr>
             <tr><td>Attendance</td><td>{{ optionalString visitorAttendance }}</td></tr>
         </table>
         {{/visitors}}
         {{^visitors}}
             <p>No data held</p>
         {{/visitors}}
-
-        <h3>Changes</h3>
-        {{#events}}
-        <table class="summary-list">
-            <tr><td>Date and time</td><td>{{ formatDate eventDateTime }}</td></tr>
-            <tr><td>Event type</td><td>{{ optionalString eventType }}</td></tr>
-            <tr><td>Description</td><td>{{ optionalString eventDescription }}</td></tr>
-            <tr><td>Staff code</td><td>{{ optionalString staffCode }}</td></tr>
-            <tr><td>Staff Name</td><td>{{ optionalString staffName }}</td></tr>
-        </table>
-        {{/events}}
 
     {{/officialVisits}}
     {{^officialVisits}}

--- a/src/main/resources/sar/templates/sar_template.mustache
+++ b/src/main/resources/sar/templates/sar_template.mustache
@@ -32,7 +32,7 @@
         {{#visitors}}
         <table class="summary-list">
             <tr><td>Relationship type</td><td>{{ optionalString relationshipType }}</td></tr>
-            <tr><td>Relationship</td><td>{{ optionalString relationshipCode }}</td></tr>
+            <tr><td>Relationship description</td><td>{{ optionalString relationshipDescription }}</td></tr>
             <tr><td>Attendance</td><td>{{ optionalString visitorAttendance }}</td></tr>
         </table>
         {{/visitors}}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/SarEndpointIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/SarEndpointIntegrationTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.integration.resource
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.annotation.Import
@@ -131,7 +130,6 @@ class SarEndpointIntegrationTest : IntegrationTestBase() {
     val response = webTestClient.getSarContent(MOORLAND_PRISONER.number, today().minusDays(1), today().plusDays(8))
 
     with(response.content.officialVisits.first()) {
-      prisonerNumber isEqualTo MOORLAND_PRISONER.number
       visitType isEqualTo VisitType.IN_PERSON
       visitStatus isEqualTo VisitStatusType.COMPLETED
       prisonerAttendance isEqualTo AttendanceType.ABSENT
@@ -139,16 +137,10 @@ class SarEndpointIntegrationTest : IntegrationTestBase() {
       prisonerNotes isEqualTo "public notes"
 
       with(visitors.first()) {
-        firstName isEqualTo "John"
-        lastName isEqualTo "Doe"
         relationshipType isEqualTo RelationshipType.OFFICIAL
         relationshipCode isEqualTo "POM"
-        visitorNotes isEqualTo "visitor notes"
         visitorAttendance isEqualTo AttendanceType.ATTENDED
       }
-
-      assertThat(events).hasSize(2)
-      assertThat(events).extracting("eventType").containsAll(listOf("Visit created", "Visit completed"))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/SarEndpointIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/SarEndpointIntegrationTest.kt
@@ -138,7 +138,7 @@ class SarEndpointIntegrationTest : IntegrationTestBase() {
 
       with(visitors.first()) {
         relationshipType isEqualTo RelationshipType.OFFICIAL
-        relationshipCode isEqualTo "POM"
+        relationshipDescription isEqualTo "Description"
         visitorAttendance isEqualTo AttendanceType.ATTENDED
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/sar/SarIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/sar/SarIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.integration.sar
 
 import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
@@ -55,6 +56,11 @@ class SarIntegrationTest :
   // defaults to "current date" which means the date in the expected output will keep
   // changing, causing the comparison with the baseline report to fail
   override fun getToDate(): LocalDate? = LocalDate.parse("2026-03-03")
+
+  @BeforeEach
+  fun `set up official visit and change history data`() {
+    personalRelationshipsApi().stubReferenceGroup()
+  }
 
   @Test
   @Sql("classpath:sar/truncate-tables-with-sar-data.sql", "classpath:sar/seed-sar-data.sql")

--- a/src/test/resources/sar/sar-api-response.json
+++ b/src/test/resources/sar/sar-api-response.json
@@ -18,7 +18,7 @@
     "visitorConcernNotes" : null,
     "visitors" : [ {
       "relationshipType" : "OFFICIAL",
-      "relationshipCode" : "CUSPO",
+      "relationshipDescription" : "Description",
       "visitorAttendance" : null
     } ]
   } ]

--- a/src/test/resources/sar/sar-api-response.json
+++ b/src/test/resources/sar/sar-api-response.json
@@ -1,61 +1,25 @@
 {
-  "prisonerNumber": "A4567AZ",
-  "fromDate": "1970-01-01",
-  "toDate": "2026-03-03",
-  "officialVisits": [
-    {
-      "officialVisitId": 1,
-      "prisonCode": "MDI",
-      "visitDate": "2026-01-01",
-      "prisonerNumber": "A4567AZ",
-      "startTime": "09:00:00",
-      "endTime": "10:00:00",
-      "dpsLocationId": "9485cf4a-750b-4d74-b594-59bacbcda247",
-      "visitType": "VIDEO",
-      "visitStatus": "SCHEDULED",
-      "completionCode": null,
-      "completionNotes": null,
-      "prisonerAttendance": null,
-      "staffNotes": null,
-      "prisonerNotes": null,
-      "visitors": [
-        {
-          "officialVisitorId": 1,
-          "firstName": "Adam",
-          "lastName": "Adams",
-          "relationshipType": "OFFICIAL",
-          "relationshipCode": "CUSPO",
-          "relationshipDescription": "TODO - lookup relationship description",
-          "visitorNotes": null,
-          "visitorAttendance": null
-        }
-      ],
-      "events": [
-        {
-          "auditedEventId": 1,
-          "eventDateTime": "2026-01-01T08:00:00",
-          "eventType": "Official visit created",
-          "eventDescription": "Detail text",
-          "staffCode": "TIM",
-          "staffName": "Staff officer"
-        },
-        {
-          "auditedEventId": 2,
-          "eventDateTime": "2026-01-02T08:00:00",
-          "eventType": "Official visit updated",
-          "eventDescription": "Detail text",
-          "staffCode": "TIM",
-          "staffName": "Staff officer"
-        },
-        {
-          "auditedEventId": 3,
-          "eventDateTime": "2026-01-03T08:00:00",
-          "eventType": "Official visit completed",
-          "eventDescription": "Detail text",
-          "staffCode": "TIM",
-          "staffName": "Staff officer"
-        }
-      ]
-    }
-  ]
+  "prisonerNumber" : "A4567AZ",
+  "fromDate" : "1970-01-01",
+  "toDate" : "2026-03-03",
+  "officialVisits" : [ {
+    "prisonCode" : "MDI",
+    "visitDate" : "2026-01-01",
+    "startTime" : "09:00:00",
+    "endTime" : "10:00:00",
+    "visitType" : "VIDEO",
+    "visitStatus" : "SCHEDULED",
+    "completionCode" : null,
+    "completionNotes" : null,
+    "prisonerAttendance" : null,
+    "staffNotes" : null,
+    "prisonerNotes" : null,
+    "searchTypeCode" : "RUB_A",
+    "visitorConcernNotes" : null,
+    "visitors" : [ {
+      "relationshipType" : "OFFICIAL",
+      "relationshipCode" : "CUSPO",
+      "visitorAttendance" : null
+    } ]
+  } ]
 }

--- a/src/test/resources/sar/sar-generated-report.html
+++ b/src/test/resources/sar/sar-generated-report.html
@@ -255,6 +255,6 @@
 
 <table class="summary-list">
   <tr><td>Relationship type</td><td>OFFICIAL</td></tr>
-  <tr><td>Relationship</td><td>CUSPO</td></tr>
+  <tr><td>Relationship description</td><td>Description</td></tr>
   <tr><td>Attendance</td><td>No Data Held</td></tr>
 </table>

--- a/src/test/resources/sar/sar-generated-report.html
+++ b/src/test/resources/sar/sar-generated-report.html
@@ -237,7 +237,6 @@
 <h3>Visit</h3>
 <table class="summary-list">
   <tr><td>Prison name</td><td>Moorland (HMP &amp; YOI)</td></tr>
-  <tr><td>Prisoner number</td><td>A4567AZ</td></tr>
   <tr><td>Visit date</td><td>01 January 2026</td></tr>
   <tr><td>Start time</td><td>09:00:00</td></tr>
   <tr><td>End time</td><td>10:00:00</td></tr>
@@ -245,51 +244,17 @@
   <tr><td>Visit status</td><td>SCHEDULED</td></tr>
   <tr><td>Staff notes</td><td>No Data Held</td></tr>
   <tr><td>Prisoner notes</td><td>No Data Held</td></tr>
-  <tr><td>Location</td><td>PROPERTY BOX 2</td></tr>
   <tr><td>Attendance</td><td>No Data Held</td></tr>
   <tr><td>Completion type</td><td>No Data Held</td></tr>
+  <tr><td>Completion notes</td><td>No Data Held</td></tr>
+  <tr><td>Search type</td><td>RUB_A</td></tr>
+  <tr><td>Visitor concern notes</td><td>No Data Held</td></tr>
 </table>
 
 <h3>Visitors</h3>
 
 <table class="summary-list">
-  <tr><td>First name</td><td>Adam</td></tr>
-  <tr><td>Last name</td><td>Adams</td></tr>
-  <tr><td>Relationship code</td><td>CUSPO</td></tr>
-  <tr><td>Relationship</td><td>TODO - lookup relationship description</td></tr>
-  <tr><td>Notes</td><td>No Data Held</td></tr>
+  <tr><td>Relationship type</td><td>OFFICIAL</td></tr>
+  <tr><td>Relationship</td><td>CUSPO</td></tr>
   <tr><td>Attendance</td><td>No Data Held</td></tr>
 </table>
-
-
-
-<h3>Changes</h3>
-
-<table class="summary-list">
-  <tr><td>Date and time</td><td>01 January 2026, 8:00:00 am</td></tr>
-  <tr><td>Event type</td><td>Official visit created</td></tr>
-  <tr><td>Description</td><td>Detail text</td></tr>
-  <tr><td>Staff code</td><td>TIM</td></tr>
-  <tr><td>Staff Name</td><td>Staff officer</td></tr>
-</table>
-
-<table class="summary-list">
-  <tr><td>Date and time</td><td>02 January 2026, 8:00:00 am</td></tr>
-  <tr><td>Event type</td><td>Official visit updated</td></tr>
-  <tr><td>Description</td><td>Detail text</td></tr>
-  <tr><td>Staff code</td><td>TIM</td></tr>
-  <tr><td>Staff Name</td><td>Staff officer</td></tr>
-</table>
-
-<table class="summary-list">
-  <tr><td>Date and time</td><td>03 January 2026, 8:00:00 am</td></tr>
-  <tr><td>Event type</td><td>Official visit completed</td></tr>
-  <tr><td>Description</td><td>Detail text</td></tr>
-  <tr><td>Staff code</td><td>TIM</td></tr>
-  <tr><td>Staff Name</td><td>Staff officer</td></tr>
-</table>
-
-
-
-
-

--- a/src/test/resources/sar/seed-sar-data.sql
+++ b/src/test/resources/sar/seed-sar-data.sql
@@ -6,5 +6,5 @@ insert into prisoner_visited (prisoner_visited_id, official_visit_id, prisoner_n
 values (1, 1, 'A4567AZ', 'TIM', current_timestamp);
 
 insert into official_visitor (official_visitor_id, official_visit_id, visitor_type_code, relationship_type_code, first_name, last_name, contact_id, prisoner_contact_id, relationship_code, lead_visitor, created_time, created_by)
-values (1, 1, 'CONTACT', 'OFFICIAL', 'Adam', 'Adams', 20085662, 7331628,'CUSPO', true, current_timestamp, 'TIM');
+values (1, 1, 'CONTACT', 'OFFICIAL', 'Adam', 'Adams', 20085662, 7331628,'POM', true, current_timestamp, 'TIM');
 

--- a/src/test/resources/sar/seed-sar-data.sql
+++ b/src/test/resources/sar/seed-sar-data.sql
@@ -8,7 +8,3 @@ values (1, 1, 'A4567AZ', 'TIM', current_timestamp);
 insert into official_visitor (official_visitor_id, official_visit_id, visitor_type_code, relationship_type_code, first_name, last_name, contact_id, prisoner_contact_id, relationship_code, lead_visitor, created_time, created_by)
 values (1, 1, 'CONTACT', 'OFFICIAL', 'Adam', 'Adams', 20085662, 7331628,'CUSPO', true, current_timestamp, 'TIM');
 
-insert into audited_event (audited_event_id, official_visit_id, prison_code, prisoner_number, event_source, user_name, user_full_name, summary_text, detail_text, event_date_time)
-values (1, 1, 'MDI', 'A4567AZ', 'DPS', 'TIM', 'Staff officer', 'Official visit created', 'Detail text', '2026-01-01T08:00:00.000000'),
-       (2, 1, 'MDI', 'A4567AZ', 'DPS', 'TIM', 'Staff officer', 'Official visit updated', 'Detail text', '2026-01-02T08:00:00.000000'),
-       (3, 1, 'MDI', 'A4567AZ', 'DPS', 'TIM', 'Staff officer', 'Official visit completed', 'Detail text', '2026-01-03T08:00:00.000000');


### PR DESCRIPTION
This pull request simplifies the Subject Access Request (SAR) visit data model and output, removing several fields and the audit event history from the SAR response and report. It also adds new fields to the visit data and updates related templates and tests to match the new structure.

This change is based on the feedback from the SAR team recorded here.
https://dsdmoj.atlassian.net/wiki/spaces/moveandimprove/pages/6148751915/Data+Dictionary+-+Official+Visits

<img width="593" height="603" alt="image" src="https://github.com/user-attachments/assets/3ebe3a35-539b-471d-bbbb-398ff9bf8584" />