### PR TITLE
OV-793 : update reference data descriptions

### DIFF
--- a/src/main/resources/migrations/common/V2026.07.13__update_reference_data.sql
+++ b/src/main/resources/migrations/common/V2026.07.13__update_reference_data.sql
@@ -1,0 +1,5 @@
+update reference_data set description = 'In person' where group_code = 'VIS_TYPE' and code = 'IN_PERSON';
+update reference_data set description = 'Phone' where group_code = 'VIS_TYPE' and code = 'TELEPHONE';
+update reference_data set description = 'Operational reasons' where group_code = 'VIS_COMPLETION' and code = 'STAFF_CANCELLED';
+update reference_data set description = 'Visitor cancellation' where group_code = 'VIS_COMPLETION' and code = 'VISITOR_CANCELLED';
+update reference_data set description = 'Prisoner cancellation' where group_code = 'VIS_COMPLETION' and code = 'PRISONER_CANCELLED';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitSearchIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitSearchIntegrationTest.kt
@@ -393,7 +393,7 @@ class OfficialVisitSearchIntegrationTest : IntegrationTestBase() {
         visitStatus isEqualTo VisitStatusType.CANCELLED
         visitStatusDescription isEqualTo "Cancelled"
         completionCode isEqualTo VisitCompletionType.VISITOR_CANCELLED
-        completionDescription isEqualTo "Visitor cancelled"
+        completionDescription isEqualTo "Visitor cancellation"
         completionNotes isEqualTo "the visitor cancelled"
         visitDate isEqualTo nextMondayAt9.visitDate
         startTime isEqualTo nextMondayAt9.startTime

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -69,7 +69,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 2026.07.01
+      expected-flyway-schema-version: 2026.07.13
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:


### PR DESCRIPTION
This pull request updates descriptions for several codes in the `reference_data` table to improve clarity and consistency for visit types and completion reasons.

Reference data updates:

* Updated the `description` for `IN_PERSON` and `TELEPHONE` in the `VIS_TYPE` group to "In person" and "Phone" respectively.
* Updated the `description` for `STAFF_CANCELLED`, `VISITOR_CANCELLED`, and `PRISONER_CANCELLED` in the `VIS_COMPLETION` group to more descriptive phrases: "Operational reasons", "Visitor cancellation", and "Prisoner cancellation".