### PR TITLE
OV-737 : some code improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/common/VisitorAndContactId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/common/VisitorAndContactId.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.common
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class VisitorAndContactId(
+  @Schema(description = "The visitor ID")
+  val visitorId: Long,
+  @Schema(description = "The contact ID (null when no contact was created)")
+  val contactId: Long?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
@@ -63,8 +63,8 @@ class OfficialVisitFacade(
           outboundEvent = OutboundEvent.VISITOR_CREATED,
           prisonCode = prisonCode,
           identifier = creationResult.officialVisitId,
-          secondIdentifier = pair.first,
-          contactId = pair.second,
+          secondIdentifier = pair.visitorId,
+          contactId = pair.contactId,
           user = user,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacade.kt
@@ -58,13 +58,13 @@ class OfficialVisitFacade(
         user = user,
       )
 
-      creationResult.visitorAndContactIds.forEach { pair ->
+      creationResult.visitorAndContactIds.forEach { visitorAndContactId ->
         outboundEventsService.send(
           outboundEvent = OutboundEvent.VISITOR_CREATED,
           prisonCode = prisonCode,
           identifier = creationResult.officialVisitId,
-          secondIdentifier = pair.visitorId,
-          contactId = pair.contactId,
+          secondIdentifier = visitorAndContactId.visitorId,
+          contactId = visitorAndContactId.contactId,
           user = user,
         )
       }
@@ -105,13 +105,13 @@ class OfficialVisitFacade(
         user = user,
       )
 
-      completedVisitDto.visitorAndContactIds.forEach { pair ->
+      completedVisitDto.visitorAndContactIds.forEach { visitorAndContactId ->
         outboundEventsService.send(
           outboundEvent = OutboundEvent.VISITOR_UPDATED,
           prisonCode = completedVisitDto.prisonCode,
           identifier = completedVisitDto.officialVisitId,
-          secondIdentifier = pair.first,
-          contactId = pair.second,
+          secondIdentifier = visitorAndContactId.visitorId,
+          contactId = visitorAndContactId.contactId,
           user = user,
         )
       }
@@ -143,13 +143,13 @@ class OfficialVisitFacade(
         user = user,
       )
 
-      cancelledVisitDto.visitorAndContactIds.forEach { pair ->
+      cancelledVisitDto.visitorAndContactIds.forEach { visitorAndContactId ->
         outboundEventsService.send(
           outboundEvent = OutboundEvent.VISITOR_UPDATED,
           prisonCode = cancelledVisitDto.prisonCode,
           identifier = cancelledVisitDto.officialVisitId,
-          secondIdentifier = pair.first,
-          contactId = pair.second,
+          secondIdentifier = visitorAndContactId.visitorId,
+          contactId = visitorAndContactId.contactId,
           user = user,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/CreateOfficialVisitResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/CreateOfficialVisitResponse.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.VisitorAndContactId
 
 data class CreateOfficialVisitResponse(
   @Schema(description = "The official visit ID")
@@ -9,11 +10,4 @@ data class CreateOfficialVisitResponse(
   val prisonerNumber: String,
   @Schema(description = "The visitor and contact IDs")
   val visitorAndContactIds: List<VisitorAndContactId>,
-)
-
-data class VisitorAndContactId(
-  @Schema(description = "The visitor ID")
-  val visitorId: Long,
-  @Schema(description = "The contact ID (null when no contact was created)")
-  val contactId: Long?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/CreateOfficialVisitResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/CreateOfficialVisitResponse.kt
@@ -1,7 +1,19 @@
 package uk.gov.justice.digital.hmpps.officialvisitsapi.model.response
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class CreateOfficialVisitResponse(
+  @Schema(description = "The official visit ID")
   val officialVisitId: Long,
+  @Schema(description = "The prisoner number")
   val prisonerNumber: String,
-  val visitorAndContactIds: List<Pair<Long, Long?>>,
+  @Schema(description = "The visitor and contact IDs")
+  val visitorAndContactIds: List<VisitorAndContactId>,
+)
+
+data class VisitorAndContactId(
+  @Schema(description = "The visitor ID")
+  val visitorId: Long,
+  @Schema(description = "The contact ID (null when no contact was created)")
+  val contactId: Long?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/NotificationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/model/response/NotificationResponse.kt
@@ -14,4 +14,8 @@ data class NotificationResponse(
   val recipients: List<NotificationRecipient>,
 )
 
-data class NotificationRecipient(val emailAddress: String, val notificationId: Long)
+data class NotificationRecipient(
+  @Schema(description = "The email address of the recipient", example = "example@example.com")
+  val emailAddress: String,
+  val notificationId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCancellationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCancellationService.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.AttendanceType
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitCancellationRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
@@ -76,7 +77,7 @@ class OfficialVisitCancellationService(
       officialVisitId = officialVisitId,
       prisonerVisitedId = prisonerVisited.prisonerVisitedId,
       prisonerNumber = prisonerVisited.prisonerNumber,
-      visitorAndContactIds = officialVisit.officialVisitors().map { it.officialVisitorId to it.contactId },
+      visitorAndContactIds = officialVisit.officialVisitors().map { VisitorAndContactId(it.officialVisitorId, it.contactId) },
     ).also {
       logger.info("Official visit with ID $officialVisitId cancelled.")
     }
@@ -87,6 +88,6 @@ class OfficialVisitCancellationService(
     val officialVisitId: Long,
     val prisonerVisitedId: Long,
     val prisonerNumber: String,
-    val visitorAndContactIds: List<Pair<Long, Long?>>,
+    val visitorAndContactIds: List<VisitorAndContactId>,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCompletionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCompletionService.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitCompletionRequest
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
@@ -88,7 +89,7 @@ class OfficialVisitCompletionService(
       officialVisitId = officialVisitId,
       prisonerVisitedId = prisonerVisited.prisonerVisitedId,
       prisonerNumber = prisonerVisited.prisonerNumber,
-      visitorAndContactIds = officialVisit.officialVisitors().map { it.officialVisitorId to it.contactId },
+      visitorAndContactIds = officialVisit.officialVisitors().map { VisitorAndContactId(it.officialVisitorId, it.contactId) },
     ).also {
       logger.info("Official visit with ID $officialVisitId completed.")
     }
@@ -99,6 +100,6 @@ class OfficialVisitCompletionService(
     val officialVisitId: Long,
     val prisonerVisitedId: Long,
     val prisonerNumber: String,
-    val visitorAndContactIds: List<Pair<Long, Long?>>,
+    val visitorAndContactIds: List<VisitorAndContactId>,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.officialvisitsapi.client.prisonersearch.PrisonerValidator
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.OfficialVisitEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.PrisonVisitSlotEntity
 import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.PrisonerVisitedEntity
@@ -16,7 +17,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.CreateOffici
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.CreateOfficialVisitResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.PrisonerContact
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonVisitSlotRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
@@ -80,7 +80,12 @@ class OfficialVisitCreateService(
         CreateOfficialVisitResponse(
           officialVisitId = it.officialVisitId,
           prisonerNumber = it.prisonerNumber,
-          visitorAndContactIds = it.officialVisitors().map { visitor -> VisitorAndContactId(visitor.officialVisitorId, visitor.contactId) },
+          visitorAndContactIds = it.officialVisitors().map { visitor ->
+            VisitorAndContactId(
+              visitor.officialVisitorId,
+              visitor.contactId,
+            )
+          },
         )
       }.also {
         logger.info("Official visit created with ID ${it.officialVisitId}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/service/OfficialVisitCreateService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.CreateOffici
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.request.OfficialVisitor
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.CreateOfficialVisitResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.PrisonerContact
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.OfficialVisitRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonVisitSlotRepository
 import uk.gov.justice.digital.hmpps.officialvisitsapi.repository.PrisonerVisitedRepository
@@ -79,7 +80,7 @@ class OfficialVisitCreateService(
         CreateOfficialVisitResponse(
           officialVisitId = it.officialVisitId,
           prisonerNumber = it.prisonerNumber,
-          visitorAndContactIds = it.officialVisitors().map { visitor -> visitor.officialVisitorId to visitor.contactId },
+          visitorAndContactIds = it.officialVisitors().map { visitor -> VisitorAndContactId(visitor.officialVisitorId, visitor.contactId) },
         )
       }.also {
         logger.info("Official visit created with ID ${it.officialVisitId}")
@@ -118,8 +119,8 @@ class OfficialVisitCreateService(
               username = user.username,
               prisonCode = prisonCode,
               officialVisitId = it.officialVisitId,
-              contactId = value.second!!,
-              officialVisitorId = value.first,
+              contactId = value.contactId!!,
+              officialVisitorId = value.visitorId,
             ),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.Sort
+import uk.gov.justice.digital.hmpps.officialvisitsapi.common.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISONER
 import uk.gov.justice.digital.hmpps.officialvisitsapi.helper.MOORLAND_PRISON_USER
@@ -26,7 +27,6 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVis
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitUpdateSlotResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitUpdateVisitorsResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitorUpdated
-import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.OfficialVisitCancellationService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.OfficialVisitCompletionService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.OfficialVisitCreateService

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/facade/OfficialVisitFacadeTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVis
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitUpdateSlotResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitUpdateVisitorsResponse
 import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.OfficialVisitorUpdated
+import uk.gov.justice.digital.hmpps.officialvisitsapi.model.response.VisitorAndContactId
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.OfficialVisitCancellationService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.OfficialVisitCompletionService
 import uk.gov.justice.digital.hmpps.officialvisitsapi.service.OfficialVisitCreateService
@@ -92,7 +93,13 @@ class OfficialVisitFacadeTest {
     )
 
     whenever(officialVisitCreateService.create(MOORLAND, request, user)).thenReturn(
-      CreateOfficialVisitResponse(officialVisitId = 1L, prisonerNumber = "A1234AA", visitorAndContactIds = listOf(Pair(1L, 1L))),
+      CreateOfficialVisitResponse(
+        officialVisitId = 1L,
+        prisonerNumber = "A1234AA",
+        visitorAndContactIds = listOf(
+          VisitorAndContactId(1L, 1L),
+        ),
+      ),
     )
 
     facade.createOfficialVisit(MOORLAND, request, MOORLAND_PRISON_USER)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/CreateOfficialVisitIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/CreateOfficialVisitIntegrationTest.kt
@@ -148,8 +148,8 @@ class CreateOfficialVisitIntegrationTest : IntegrationTestBase() {
           source = Source.DPS,
           username = MOORLAND_PRISON_USER.username,
           prisonCode = MOORLAND,
-          contactId = officialVisitResponse.visitorAndContactIds.first().second!!,
-          officialVisitorId = officialVisitResponse.visitorAndContactIds.first().first,
+          contactId = officialVisitResponse.visitorAndContactIds.first().contactId!!,
+          officialVisitorId = officialVisitResponse.visitorAndContactIds.first().visitorId!!,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitUpdateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/OfficialVisitUpdateIntegrationTest.kt
@@ -235,8 +235,8 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
           source = Source.DPS,
           username = MOORLAND_PRISON_USER.username,
           prisonCode = MOORLAND,
-          contactId = scheduledVisit?.visitorAndContactIds?.first()?.second!!,
-          officialVisitorId = scheduledVisit?.visitorAndContactIds?.first()?.first!!,
+          contactId = scheduledVisit?.visitorAndContactIds?.first()?.contactId!!,
+          officialVisitorId = scheduledVisit?.visitorAndContactIds?.first()?.visitorId!!,
         ),
       ),
     )
@@ -251,8 +251,8 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
           source = Source.DPS,
           username = MOORLAND_PRISON_USER.username,
           prisonCode = MOORLAND,
-          contactId = scheduledVisit?.visitorAndContactIds?.last()?.second!!,
-          officialVisitorId = scheduledVisit?.visitorAndContactIds?.last()?.first!!,
+          contactId = scheduledVisit?.visitorAndContactIds?.last()?.contactId!!,
+          officialVisitorId = scheduledVisit?.visitorAndContactIds?.last()?.visitorId!!,
         ),
       ),
     )
@@ -286,10 +286,10 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
           ),
           // Update - contactId = 123 and delete their equipment
           OfficialVisitor(
-            officialVisitorId = scheduledVisit?.visitorAndContactIds?.first()?.first!!,
+            officialVisitorId = scheduledVisit?.visitorAndContactIds?.first()?.visitorId!!,
             visitorTypeCode = VisitorType.CONTACT,
             relationshipCode = "POM",
-            contactId = scheduledVisit?.visitorAndContactIds?.first()?.second,
+            contactId = scheduledVisit?.visitorAndContactIds?.first()?.contactId!!,
             prisonerContactId = 456,
             leadVisitor = false,
             assistedVisit = true,
@@ -301,8 +301,8 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
       ),
     )
 
-    val existingVisitorId = scheduledVisit?.visitorAndContactIds?.first()?.first
-    val deletedVisitorId = scheduledVisit?.visitorAndContactIds?.last()?.first
+    val existingVisitorId = scheduledVisit?.visitorAndContactIds?.first()?.visitorId
+    val deletedVisitorId = scheduledVisit?.visitorAndContactIds?.last()?.visitorId
 
     verify(metricsService).send(
       eventType = eq(
@@ -314,7 +314,7 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
           source = Source.DPS,
           username = MOORLAND_PRISON_USER.username,
           prisonCode = MOORLAND,
-          contactId = scheduledVisit?.visitorAndContactIds?.last()?.second!!,
+          contactId = scheduledVisit?.visitorAndContactIds?.last()?.contactId!!,
           officialVisitorId = deletedVisitorId!!,
         ),
       ),
@@ -348,7 +348,7 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
         officialVisitId = result.officialVisitId,
       ),
       personReference = PersonReference(
-        contactId = scheduledVisit?.visitorAndContactIds?.first()?.second!!,
+        contactId = scheduledVisit?.visitorAndContactIds?.first()?.contactId!!,
       ),
     )
 
@@ -362,7 +362,7 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
         officialVisitId = result.officialVisitId,
       ),
       personReference = PersonReference(
-        contactId = scheduledVisit?.visitorAndContactIds?.last()?.second!!,
+        contactId = scheduledVisit?.visitorAndContactIds?.last()?.contactId!!,
       ),
     )
 
@@ -447,7 +447,7 @@ class OfficialVisitUpdateIntegrationTest : IntegrationTestBase() {
             officialVisitorId = Long.MAX_VALUE,
             visitorTypeCode = VisitorType.CONTACT,
             relationshipCode = "POM",
-            contactId = scheduledVisit?.visitorAndContactIds?.first()?.second,
+            contactId = scheduledVisit?.visitorAndContactIds?.first()?.contactId,
             prisonerContactId = 456,
             leadVisitor = false,
             assistedVisit = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitIntegrationTest.kt
@@ -412,13 +412,13 @@ class SyncOfficialVisitIntegrationTest : IntegrationTestBase() {
       event = OutboundEvent.VISITOR_DELETED,
       additionalInfo = VisitorInfo(
         officialVisitId = officialVisit.officialVisitId,
-        officialVisitorId = officialVisit.visitorAndContactIds.first().first,
+        officialVisitorId = officialVisit.visitorAndContactIds.first().visitorId,
         source = Source.NOMIS,
         username = UserService.getClientAsUser("NOMIS").username,
         prisonId = MOORLAND,
       ),
       PersonReference(
-        contactId = officialVisit.visitorAndContactIds.first().second ?: 0L,
+        contactId = officialVisit.visitorAndContactIds.first().contactId ?: 0L,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/integration/resource/sync/SyncOfficialVisitorsIntegrationTest.kt
@@ -184,20 +184,20 @@ class SyncOfficialVisitorsIntegrationTest : IntegrationTestBase() {
 
     webTestClient.syncDeleteVisitor(
       officialVisitId = savedVisit.officialVisitId,
-      officialVisitorId = savedVisit.visitorAndContactIds.first().first,
+      officialVisitorId = savedVisit.visitorAndContactIds.first().visitorId,
     ).expectStatus().isNoContent
 
     stubEvents.assertHasEvent(
       event = OutboundEvent.VISITOR_DELETED,
       additionalInfo = VisitorInfo(
         officialVisitId = savedVisit.officialVisitId,
-        officialVisitorId = savedVisit.visitorAndContactIds.first().first,
+        officialVisitorId = savedVisit.visitorAndContactIds.first().visitorId,
         source = Source.NOMIS,
         username = "NOMIS",
         prisonId = MOORLAND,
       ),
       personReference = PersonReference(
-        contactId = savedVisit.visitorAndContactIds.first().second ?: 0L,
+        contactId = savedVisit.visitorAndContactIds.first().contactId ?: 0L,
       ),
     )
 


### PR DESCRIPTION
This pull request refactors how visitor and contact IDs are represented in the codebase, replacing the use of `Pair<Long, Long?>` with a new `VisitorAndContactId` data class. This change improves type safety and clarity. The update also adds schema annotations for better API documentation and updates all affected service, facade, and test code to use the new structure.


These changes enhance readability, maintainability, and documentation quality for the official visits API.