### PR TITLE
OV-855 initial data model and scripts to support the capture of visits for review data, note this is missing the view to query the data.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/VisitReviewDetailEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/VisitReviewDetailEntity.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "visit_review_detail")
+class VisitReviewDetailEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val visitReviewDetailId: Long = 0,
+
+  @ManyToOne
+  @JoinColumn(name = "visit_review_id")
+  val visitReview: VisitReviewEntity,
+
+  val raisedTime: LocalDateTime,
+
+  @Enumerated(EnumType.STRING)
+  val issueType: IssueType,
+
+  val issueDetail: String? = null,
+) {
+  var acknowledgedTime: LocalDateTime? = null
+
+  var acknowledgedBy: String? = null
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as VisitReviewDetailEntity
+
+    return visitReviewDetailId == other.visitReviewDetailId
+  }
+
+  override fun hashCode(): Int = visitReviewDetailId.hashCode()
+}
+
+enum class IssueType {
+  PRISONER_NEW_ALERT,
+  PRISONER_NEW_RESTRICTION,
+  PRISONER_RELEASED,
+  PRISONER_TRANSFERRED,
+  VISITOR_NO_RELATIONSHIP,
+  VISITOR_NOT_APPROVED,
+  VISITOR_NOT_OFFICIAL,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/VisitReviewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/VisitReviewEntity.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "visit_review")
+class VisitReviewEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val visitReviewId: Long = 0,
+
+  val officialVisitId: Long,
+
+  @OneToMany(mappedBy = "visitReview", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
+  private val visitReviewDetails: MutableList<VisitReviewDetailEntity> = mutableListOf(),
+
+  val raisedTime: LocalDateTime,
+) {
+  var expiredTime: LocalDateTime? = null
+
+  fun addVisitReviewDetails(
+    raisedTime: LocalDateTime,
+    issueType: IssueType,
+    issueDetail: String?,
+  ) {
+    visitReviewDetails.add(
+      VisitReviewDetailEntity(
+        visitReview = this,
+        raisedTime = raisedTime,
+        issueType = issueType,
+        issueDetail = issueDetail,
+      ),
+    )
+  }
+
+  fun visitReviewDetails() = visitReviewDetails.toList()
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as VisitReviewEntity
+
+    return visitReviewId == other.visitReviewId
+  }
+
+  override fun hashCode(): Int = visitReviewId.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/VisitReviewQueueEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/entity/VisitReviewQueueEntity.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "visit_review_queue")
+class VisitReviewQueueEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val visitReviewQueueId: Long = 0,
+
+  val officialVisitId: Long,
+
+  val createdTime: LocalDateTime,
+
+  val triggeringEvent: String,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+
+    other as VisitReviewQueueEntity
+
+    return visitReviewQueueId == other.visitReviewQueueId
+  }
+
+  override fun hashCode(): Int = visitReviewQueueId.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/VisitReviewQueueRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/VisitReviewQueueRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.VisitReviewQueueEntity
+
+@Repository
+interface VisitReviewQueueRepository : JpaRepository<VisitReviewQueueEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/VisitReviewRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/officialvisitsapi/repository/VisitReviewRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.officialvisitsapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.officialvisitsapi.entity.VisitReviewEntity
+
+@Repository
+interface VisitReviewRepository : JpaRepository<VisitReviewEntity, Long>

--- a/src/main/resources/migrations/common/V2026.08.10__add_visit_review_tables.sql
+++ b/src/main/resources/migrations/common/V2026.08.10__add_visit_review_tables.sql
@@ -32,4 +32,4 @@ CREATE TABLE visit_review_detail
 );
 
 CREATE INDEX idx_visit_review_detail_issue_type ON visit_review_detail (issue_type);
-CREATE INDEX idx_visit_review_acknowledgement_time ON visit_review_detail (acknowledgement_time);
+CREATE INDEX idx_visit_review_detail_acknowledgement_time ON visit_review_detail (acknowledgement_time);

--- a/src/main/resources/migrations/common/V2026.08.10__add_visit_review_tables.sql
+++ b/src/main/resources/migrations/common/V2026.08.10__add_visit_review_tables.sql
@@ -1,0 +1,35 @@
+CREATE TABLE visit_review_queue
+(
+  visit_review_queue_id BIGSERIAL PRIMARY KEY,
+  official_visit_id     BIGINT NOT NULL,
+  created_time          TIMESTAMP NOT NULL,
+  triggering_event      VARCHAR(40) NOT NULL
+);
+
+CREATE INDEX idx_visit_review_queue_official_visit_id ON visit_review_queue (official_visit_id);
+CREATE INDEX idx_visit_review_queue_triggering_event ON visit_review_queue (triggering_event);
+
+CREATE TABLE visit_review
+(
+  visit_review_id   BIGSERIAL PRIMARY KEY,
+  official_visit_id BIGINT NOT NULL,
+  raised_time       TIMESTAMP NOT NULL,
+  expired_time      TIMESTAMP
+);
+
+CREATE INDEX idx_visit_review_official_visit_id ON visit_review (official_visit_id);
+CREATE INDEX idx_visit_review_expired_time ON visit_review (expired_time);
+
+CREATE TABLE visit_review_detail
+(
+  visit_review_detail_id   BIGSERIAL PRIMARY KEY,
+  visit_review_id          BIGINT NOT NULL references visit_review(visit_review_id),
+  raised_time              TIMESTAMP NOT NULL,
+  issue_type               VARCHAR(40) NOT NULL,
+  issue_detail             VARCHAR(100),
+  acknowledgement_time     TIMESTAMP,
+  acknowledged_by          VARCHAR(60) NOT NULL
+);
+
+CREATE INDEX idx_visit_review_detail_issue_type ON visit_review_detail (issue_type);
+CREATE INDEX idx_visit_review_acknowledgement_time ON visit_review_detail (acknowledgement_time);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -70,7 +70,7 @@ hmpps:
   sar:
     tests:
       attachments-expected: false
-      expected-flyway-schema-version: 2026.07.13
+      expected-flyway-schema-version: 2026.08.10
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:

--- a/src/test/resources/sar/entity-schema.json
+++ b/src/test/resources/sar/entity-schema.json
@@ -201,5 +201,27 @@
     "updatedBy": "String",
     "updatedTime": "LocalDateTime",
     "visitorEquipmentId": "long"
+  },
+  "VisitReviewQueueEntity": {
+    "visitReviewQueueId": "long",
+    "officialVisitId": "long",
+    "createdTime": "LocalDateTime",
+    "triggeringEvent": "String"
+  },
+  "VisitReviewEntity": {
+    "expiredTime": "LocalDateTime",
+    "officialVisitId": "long",
+    "raisedTime": "LocalDateTime",
+    "visitReviewDetails":"List",
+    "visitReviewId": "long"
+  },
+  "VisitReviewDetailEntity": {
+    "acknowledgedBy":"String",
+    "acknowledgedTime":"LocalDateTime",
+    "issueDetail":"String",
+    "issueType":"IssueType",
+    "raisedTime":"LocalDateTime",
+    "visitReview":"VisitReviewEntity",
+    "visitReviewDetailId":"long"
   }
 }


### PR DESCRIPTION
This PR contains the main entities and repositories for capturing the data related to visits for review.

It does not contain the SQL view (yet) which will be needed to query data to be used by the UI.